### PR TITLE
Update libcap license identifier

### DIFF
--- a/recipes-core/libcap/libcap_%.bbappend
+++ b/recipes-core/libcap/libcap_%.bbappend
@@ -1,2 +1,2 @@
 # add proper SPDX license identifier
-LICENSE = "BSD-3-Clause | GPL-2.0-only"
+LICENSE = "BSD-3-Clause | GPLv2"


### PR DESCRIPTION
Bitbake does not understand the SPDX license identifier GPL-2.0-only,
resulting in:
`WARNING: mc:sc573-gen6:libcap-2.32-r0 do_populate_lic: libcap: No generic license file exists for: GPL-2.0-only in any provider`

Thus, the license identifier is changed back to GPLv2, which bitbake
understands to be GPLv2 only