### PR TITLE
Add multiconfig for qemux86-64 build target

### DIFF
--- a/classes/irma-6-firmware-zip.bbclass
+++ b/classes/irma-6-firmware-zip.bbclass
@@ -1,5 +1,18 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2021 iris-GmbH infrared & intelligent sensors
+#
+#
+# This class archives all necessary components into a release zip file
+#
+# The following variables must be defined in machine- / local- / multiconfig:
+# - FLASH_FSTYPE
+# - FIRMWARE_ZIP_KERNEL_NAME
+# - FIRMWARE_ZIP_DEVTREE_NAME
+# - FIRMWARE_ZIP_BOOTLOADER_NAME
+# - IMAGE_LINK_NAME
+#
+# For some targets it can be useful to skip this class (e.g. qemu).
+# In this case set the variable SKIP_FIRMWARE_ZIP to "1" in the multiconfig
 
 do_createfirmwarezip[depends] += "${PN}:do_image_complete"
 do_createfirmwarezip[depends] += "virtual/kernel:do_deploy"
@@ -13,6 +26,9 @@ python do_createfirmwarezip() {
     import yaml
     import errno
     import tempfile
+
+    if d.getVar('SKIP_FIRMWARE_ZIP', True) == "1":
+        return
 
     pn = d.getVar('PN', True)
     deploy_dir = d.getVar('DEPLOY_DIR_IMAGE', True)

--- a/conf/multiconfig/qemux86-64.conf
+++ b/conf/multiconfig/qemux86-64.conf
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2021 iris-GmbH infrared & intelligent sensors
+
+MACHINE = "qemux86-64"
+PREFERRED_PROVIDER_virtual/bootloader = "u-boot"
+# skip firmware zip step, as this is a local development image
+SKIP_FIRMWARE_ZIP = "1"
+# whitelist mongoose for qemux86, as it is only used during development: https://cesanta.com/licensing.html
+LICENSE_FLAGS_WHITELIST += "commercial_mongoose"


### PR DESCRIPTION
This commit enables us to build our firmware for the qemux86-64 target.
Additionally the class irma-6-firmware-zip can now be skipped for
individual targets by setting SKIP_FIRMWARE_ZIP = "1" in the appropriate
multiconfig.