### PR TITLE
Move DISTRO_VERSION declaration to KAS repository

### DIFF
--- a/conf/distro/poky-iris.conf
+++ b/conf/distro/poky-iris.conf
@@ -3,7 +3,7 @@
 
 require conf/distro/poky.conf
 
-DISTRO_VERSION = "1.1.26-dev"
+DISTRO_VERSION = "${IRMA6_DISTRO_VERSION}"
 DISTRO = "poky-iris"
 DISTRO_NAME = "IRIS IRMA6"
 unset DISTRO_CODENAME


### PR DESCRIPTION
As the KAS repository is responsible for the overall versioning, the
DISTRO_VERSION should be defined there as well. Unfortunately, it is not
possible to set the variable outside of the distro config, however one
can refer to the value of an arbitrary variable from the local configs global
scope.