### PR TITLE
[RDSBUG-568] Introduce bootloader versioning

### DIFF
--- a/classes/irma6-firmware-zip.bbclass
+++ b/classes/irma6-firmware-zip.bbclass
@@ -17,6 +17,8 @@
 do_createfirmwarezip[depends] += "${PN}:do_image_complete"
 do_createfirmwarezip[depends] += "virtual/kernel:do_deploy"
 do_createfirmwarezip[depends] += "virtual/bootloader:do_deploy"
+# we need the sysroot to access u-boot versioning file
+do_createfirmwarezip[deptask] += "do_populate_sysroot"
 do_createfirmwarezip[nostamp] = "1"
 
 DEPENDS += "python3-pyyaml-native"
@@ -67,6 +69,11 @@ python do_createfirmwarezip() {
         for f in file_list:
             meta[metatype][f] = { 'file': os.path.basename(deployfiles[f]) }
         meta["version"] = version_string
+        # additionally, add the bootloader versioning to the meta.yml file
+        if metatype == "bootloader":
+            with open(d.getVar('STAGING_DIR_HOST', True) + d.getVar('datadir', True) + '/uboot.release','r') as f:
+                bootloader_version = f.readline().rstrip()
+            meta["bootloader-version"] = bootloader_version
 
         # Write meta.yaml to /tmp
         meta_temp = tempfile.NamedTemporaryFile(mode = "w")

--- a/recipes-bsp/u-boot/u-boot-adi.bbappend
+++ b/recipes-bsp/u-boot/u-boot-adi.bbappend
@@ -32,3 +32,11 @@ SRC_URI += " \
     file://0020-add-localversion-iris.patch \
     file://0021-remove-space-from-localversion-adi.patch \
 "
+
+# add the file containing the u-boot version string to the sysroot,
+# so that we can consume it within other recipes.
+FILES_${PN}-dev += "${datadir}/uboot.release"
+do_install_append() {
+    install -d ${D}/${datadir}
+    install ${B}/include/config/uboot.release ${D}${datadir}/uboot.release
+}

--- a/recipes-bsp/u-boot/u-boot-imx_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-imx_%.bbappend
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2021 iris-GmbH infrared & intelligent sensors
+
+# add the file containing the u-boot version string to the sysroot,
+# so that we can consume it within other recipes.
+FILES_${PN}-dev += "${datadir}/uboot.release"
+do_install_append() {
+    install -d ${D}/${datadir}
+    install ${B}/.scmversion ${D}${datadir}/uboot.release
+}


### PR DESCRIPTION
The bootloader version can now be tracked within the bootloader
update_file's meta.yml (bootloader-version), as well as within the operating systems rootfs
(variable BOOTLOADER_VERSION in /etc/os-release). Also, the version of
the associated is written to the bootloaders meta.yml file.