### PR TITLE
[RDSBUG-568] Add timestamp to FIRMWARE_VERSION on dev builds

### DIFF
--- a/classes/irma6-versioning.bbclass
+++ b/classes/irma6-versioning.bbclass
@@ -2,8 +2,12 @@
 # Copyright (C) 2021 iris-GmbH infrared & intelligent sensors
 #
 #
-# This file should be inherited by image recipes as it provides an identical
-# version identifier within the running OS itself, as well as inside the
-# update_files meta.yml file.
+# This file is to be inherited by image recipes as it provides an reliable
+# build identifier throughout the development and after release.
 
-FIRMWARE_VERSION = "${@d.getVar('PN', True) + '-' + d.getVar('PV', True)}"
+# If this is a pre-release build, append the build timestamp
+FIRMWARE_VERSION = "${@ \
+    d.getVar('PN', True) + '-' + d.getVar('PV', True) + '-' + d.getVar('IMAGE_NAME', True)[-14:] \
+    if d.getVar('PV', True).endswith('-dev') \
+    else \
+    d.getVar('PN', True) + '-' + d.getVar('PV', True)}"


### PR DESCRIPTION
If IRMA6_DISTRO_VERSION is appended with the "-dev" suffix, any build is
treated as a non-release build and as such the PV is not sufficiant for an
exact build identification, which was an issue in the past.
To mitigate this issue, the "-dev" suffix now appends the timestamp of
the build to the FIRMWARE_VERSION variable.