### PR TITLE
Remove static ip, which is configured by the eth0-pre-up script if ne…

### DIFF
--- a/recipes-core/init-ifupdown/init-ifupdown/interfaces
+++ b/recipes-core/init-ifupdown/init-ifupdown/interfaces
@@ -6,6 +6,4 @@ iface lo inet loopback
 
 # Wired or wireless interfaces
 auto eth0
-iface eth0 inet static
-  address 192.168.240.254
-  netmask 255.255.254.0
+iface eth0 inet manual


### PR DESCRIPTION
This allows to enable the static ip only in the maintenance build. It is deactivated for a deploy build.