### PR TITLE
jenkinsfile: Disable failfast

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,6 @@ pipeline {
     agent any
     options {
         disableConcurrentBuilds()
-        parallelsAlwaysFailFast()
     }
     environment {
         // S3 bucket for saving release artifacts

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -190,30 +190,32 @@ pipeline {
                 stages {
                     stage('Run QEMU Tests') {
                         steps {
-                            awsCodeBuild buildSpecFile: 'buildspecs/qemu_tests.yml',
-                                projectName: 'iris-devops-kas-large-amd-qemu-codebuild',
-                                credentialsType: 'keys',
-                                region: 'eu-central-1',
-                                sourceControlType: 'project',
-                                sourceTypeOverride: 'S3',
-                                sourceLocationOverride: "${S3_BUCKET}/${JOB_NAME}/${GIT_COMMIT}/iris-kas-sources.zip",
-                                secondarySourcesOverride: """[
-                                    {
-                                        "type": "S3",
-                                        "location": "${S3_TEMP_BUCKET}/${JOB_NAME}/${GIT_COMMIT}/${MULTI_CONF}-deploy.zip",
-                                        "sourceIdentifier": "deploy"
-                                    }
-                                ]""",
-                                artifactTypeOverride: 'S3',
-                                artifactLocationOverride: "${S3_TEMP_BUCKET}",
-                                artifactPathOverride: "${JOB_NAME}/${GIT_COMMIT}",
-                                artifactNamespaceOverride: 'NONE',
-                                artifactNameOverride: "${MULTI_CONF}-reports.zip",
-                                artifactPackagingOverride: 'ZIP',
-                                downloadArtifacts: 'true',
-                                envVariables: """[
-                                    { MULTI_CONF, $MULTI_CONF }
-                                ]"""
+                            catchError(buildResult: 'UNSTABLE', stageResult: 'UNSTABLE') {
+                                awsCodeBuild buildSpecFile: 'buildspecs/qemu_tests.yml',
+                                    projectName: 'iris-devops-kas-large-amd-qemu-codebuild',
+                                    credentialsType: 'keys',
+                                    region: 'eu-central-1',
+                                    sourceControlType: 'project',
+                                    sourceTypeOverride: 'S3',
+                                    sourceLocationOverride: "${S3_BUCKET}/${JOB_NAME}/${GIT_COMMIT}/iris-kas-sources.zip",
+                                    secondarySourcesOverride: """[
+                                        {
+                                            "type": "S3",
+                                            "location": "${S3_TEMP_BUCKET}/${JOB_NAME}/${GIT_COMMIT}/${MULTI_CONF}-deploy.zip",
+                                            "sourceIdentifier": "deploy"
+                                        }
+                                    ]""",
+                                    artifactTypeOverride: 'S3',
+                                    artifactLocationOverride: "${S3_TEMP_BUCKET}",
+                                    artifactPathOverride: "${JOB_NAME}/${GIT_COMMIT}",
+                                    artifactNamespaceOverride: 'NONE',
+                                    artifactNameOverride: "${MULTI_CONF}-reports.zip",
+                                    artifactPackagingOverride: 'ZIP',
+                                    downloadArtifacts: 'true',
+                                    envVariables: """[
+                                        { MULTI_CONF, $MULTI_CONF }
+                                    ]"""
+                            }
                         }
                         post {
                             always {


### PR DESCRIPTION
Failfast will cause AWS codebuild builds to be marked as "aborted"
instead of "failed".