### PR TITLE
Manually download QEMU test results

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -211,7 +211,7 @@ pipeline {
                                     artifactNamespaceOverride: 'NONE',
                                     artifactNameOverride: "${MULTI_CONF}-reports.zip",
                                     artifactPackagingOverride: 'ZIP',
-                                    downloadArtifacts: 'true',
+                                    downloadArtifacts: 'false',
                                     envVariables: """[
                                         { MULTI_CONF, $MULTI_CONF }
                                     ]"""
@@ -220,7 +220,11 @@ pipeline {
                         post {
                             always {
                                 // add test reports to pipeline run
-                                unzip zipFile: "${JOB_NAME}/${GIT_COMMIT}/${MULTI_CONF}-reports.zip", dir: "${MULTI_CONF}-reports"
+                                s3Download bucket: "${S3_TEMP_BUCKET}",
+                                    path: "${JOB_NAME}/${GIT_COMMIT}/${MULTI_CONF}-reports.zip",
+                                    file: "${MULTI_CONF}-reports.zip",
+                                    payloadSigningEnabled: true
+                                unzip zipFile: "${MULTI_CONF}-reports.zip", dir: "${MULTI_CONF}-reports"
                                 junit testResults: "${MULTI_CONF}-reports/**/*.xml", skipPublishingChecks: true
                             }
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -190,32 +190,30 @@ pipeline {
                 stages {
                     stage('Run QEMU Tests') {
                         steps {
-                            catchError(buildResult: 'UNSTABLE', stageResult: 'UNSTABLE') {
-                                awsCodeBuild buildSpecFile: 'buildspecs/qemu_tests.yml',
-                                    projectName: 'iris-devops-kas-large-amd-qemu-codebuild',
-                                    credentialsType: 'keys',
-                                    region: 'eu-central-1',
-                                    sourceControlType: 'project',
-                                    sourceTypeOverride: 'S3',
-                                    sourceLocationOverride: "${S3_BUCKET}/${JOB_NAME}/${GIT_COMMIT}/iris-kas-sources.zip",
-                                    secondarySourcesOverride: """[
-                                        {
-                                            "type": "S3",
-                                            "location": "${S3_TEMP_BUCKET}/${JOB_NAME}/${GIT_COMMIT}/${MULTI_CONF}-deploy.zip",
-                                            "sourceIdentifier": "deploy"
-                                        }
-                                    ]""",
-                                    artifactTypeOverride: 'S3',
-                                    artifactLocationOverride: "${S3_TEMP_BUCKET}",
-                                    artifactPathOverride: "${JOB_NAME}/${GIT_COMMIT}",
-                                    artifactNamespaceOverride: 'NONE',
-                                    artifactNameOverride: "${MULTI_CONF}-reports.zip",
-                                    artifactPackagingOverride: 'ZIP',
-                                    downloadArtifacts: 'false',
-                                    envVariables: """[
-                                        { MULTI_CONF, $MULTI_CONF }
-                                    ]"""
-                            }
+                            awsCodeBuild buildSpecFile: 'buildspecs/qemu_tests.yml',
+                                projectName: 'iris-devops-kas-large-amd-qemu-codebuild',
+                                credentialsType: 'keys',
+                                region: 'eu-central-1',
+                                sourceControlType: 'project',
+                                sourceTypeOverride: 'S3',
+                                sourceLocationOverride: "${S3_BUCKET}/${JOB_NAME}/${GIT_COMMIT}/iris-kas-sources.zip",
+                                secondarySourcesOverride: """[
+                                    {
+                                        "type": "S3",
+                                        "location": "${S3_TEMP_BUCKET}/${JOB_NAME}/${GIT_COMMIT}/${MULTI_CONF}-deploy.zip",
+                                        "sourceIdentifier": "deploy"
+                                    }
+                                ]""",
+                                artifactTypeOverride: 'S3',
+                                artifactLocationOverride: "${S3_TEMP_BUCKET}",
+                                artifactPathOverride: "${JOB_NAME}/${GIT_COMMIT}",
+                                artifactNamespaceOverride: 'NONE',
+                                artifactNameOverride: "${MULTI_CONF}-reports.zip",
+                                artifactPackagingOverride: 'ZIP',
+                                downloadArtifacts: 'false',
+                                envVariables: """[
+                                    { MULTI_CONF, $MULTI_CONF }
+                                ]"""
                         }
                         post {
                             always {


### PR DESCRIPTION
Workaround for a bug in AWS Codebuild, which would cause downloading the
artifacts from the codebuild instance to fail in a parallel step
scenario.