### PR TITLE
feature/ersc/RDPHOEN-817_autohandle_emmc_partitions_in_uboot

### DIFF
--- a/recipes-bsp/u-boot/u-boot-imx/0001-Backport-cmd-fs-Use-part_get_info_by_dev_and_name_or.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/0001-Backport-cmd-fs-Use-part_get_info_by_dev_and_name_or.patch
@@ -1,10 +1,11 @@
-From 9e0afbd9a0507b397ed65ac77cc7b940f4b5419d Mon Sep 17 00:00:00 2001
+From 0abcdbbac744c5d9bf5546b8c5fbc3217a6def4f Mon Sep 17 00:00:00 2001
 From: Erik Schumacher <erik.schumacher@iris-sensing.com>
 Date: Fri, 8 Oct 2021 13:37:34 +0200
 Subject: [PATCH] Backport: cmd: fs: Use part_get_info_by_dev_and_name_or_num
  to parse partitions
 
 This allows using dev#partlabel syntax.
+
 ---
  fs/fs.c        |  4 ++--
  include/part.h | 10 +++++++++-
@@ -26,7 +27,7 @@ index 0c66d60477..88d23435fe 100644
  		return -1;
  
 diff --git a/include/part.h b/include/part.h
-index c65c1c22d7..4a033d5756 100644
+index 35c8fc45a4..9e311c7677 100644
 --- a/include/part.h
 +++ b/include/part.h
 @@ -216,7 +216,7 @@ int part_get_info_by_name(struct blk_desc *dev_desc,
@@ -53,6 +54,3 @@ index c65c1c22d7..4a033d5756 100644
  #endif
  
  /*
--- 
-2.31.1
-

--- a/recipes-bsp/u-boot/u-boot-imx/0002-Backport-part-Give-several-functions-more-useful-ret.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/0002-Backport-part-Give-several-functions-more-useful-ret.patch
@@ -1,0 +1,185 @@
+From 55f3e4f169d3a84366cf45afa213a1751cb2629e Mon Sep 17 00:00:00 2001
+From: Erik Schumacher <erik.schumacher@iris-sensing.com>
+Date: Fri, 17 Dec 2021 10:41:32 +0100
+Subject: [PATCH] Backport: part: Give several functions more useful return
+ values
+
+Several functions in disk/part.c just return -1 on error. This makes them
+return different errnos for different failures. This helps callers
+differentiate between failures, even if they cannot read stdout.
+
+https://source.denx.de/u-boot/u-boot/-/commit/59715754e1d1d9279f38d70df1c3c2949a5e5203
+
+---
+ disk/part.c | 50 ++++++++++++++++++++++++++++----------------------
+ 1 file changed, 28 insertions(+), 22 deletions(-)
+
+diff --git a/disk/part.c b/disk/part.c
+index 4cc2fc19f7..7db5e3c78d 100644
+--- a/disk/part.c
++++ b/disk/part.c
+@@ -348,7 +348,7 @@ int part_get_info(struct blk_desc *dev_desc, int part,
+ 	}
+ #endif /* CONFIG_HAVE_BLOCK_DEVICE */
+ 
+-	return -1;
++	return -ENOENT;
+ }
+ 
+ int part_get_info_whole_disk(struct blk_desc *dev_desc, disk_partition_t *info)
+@@ -409,7 +409,7 @@ int blk_get_device_by_str(const char *ifname, const char *dev_hwpart_str,
+ 	*dev_desc = get_dev_hwpart(ifname, dev, hwpart);
+ 	if (!(*dev_desc) || ((*dev_desc)->type == DEV_TYPE_UNKNOWN)) {
+ 		debug("** Bad device %s %s **\n", ifname, dev_hwpart_str);
+-		dev = -ENOENT;
++		dev = -ENODEV;
+ 		goto cleanup;
+ 	}
+ 
+@@ -433,7 +433,7 @@ int blk_get_device_part_str(const char *ifname, const char *dev_part_str,
+ 			     struct blk_desc **dev_desc,
+ 			     disk_partition_t *info, int allow_whole_dev)
+ {
+-	int ret = -1;
++	int ret;
+ 	const char *part_str;
+ 	char *dup_str = NULL;
+ 	const char *dev_str;
+@@ -475,7 +475,7 @@ int blk_get_device_part_str(const char *ifname, const char *dev_part_str,
+ 	if (0 == strcmp(ifname, "ubi")) {
+ 		if (!ubifs_is_mounted()) {
+ 			printf("UBIFS not mounted, use ubifsmount to mount volume first!\n");
+-			return -1;
++			return -EINVAL;
+ 		}
+ 
+ 		*dev_desc = NULL;
+@@ -497,6 +497,7 @@ int blk_get_device_part_str(const char *ifname, const char *dev_part_str,
+ 	/* If still no dev_part_str, it's an error */
+ 	if (!dev_part_str) {
+ 		printf("** No device specified **\n");
++		ret = -ENODEV;
+ 		goto cleanup;
+ 	}
+ 
+@@ -513,8 +514,10 @@ int blk_get_device_part_str(const char *ifname, const char *dev_part_str,
+ 
+ 	/* Look up the device */
+ 	dev = blk_get_device_by_str(ifname, dev_str, dev_desc);
+-	if (dev < 0)
++	if (dev < 0) {
++		ret = dev;
+ 		goto cleanup;
++	}
+ 
+ 	/* Convert partition ID string to number */
+ 	if (!part_str || !*part_str) {
+@@ -531,6 +534,7 @@ int blk_get_device_part_str(const char *ifname, const char *dev_part_str,
+ 		if (*ep || (part == 0 && !allow_whole_dev)) {
+ 			printf("** Bad partition specification %s %s **\n",
+ 			    ifname, dev_part_str);
++			ret = -ENOENT;
+ 			goto cleanup;
+ 		}
+ 	}
+@@ -544,6 +548,7 @@ int blk_get_device_part_str(const char *ifname, const char *dev_part_str,
+ 		if (!(*dev_desc)->lba) {
+ 			printf("** Bad device size - %s %s **\n", ifname,
+ 			       dev_str);
++			ret = -EINVAL;
+ 			goto cleanup;
+ 		}
+ 
+@@ -555,6 +560,7 @@ int blk_get_device_part_str(const char *ifname, const char *dev_part_str,
+ 		if ((part > 0) || (!allow_whole_dev)) {
+ 			printf("** No partition table - %s %s **\n", ifname,
+ 			       dev_str);
++			ret = -EPROTONOSUPPORT;
+ 			goto cleanup;
+ 		}
+ 
+@@ -623,7 +629,6 @@ int blk_get_device_part_str(const char *ifname, const char *dev_part_str,
+ 				*info = tmpinfo;
+ 		} else {
+ 			printf("** No valid partitions found **\n");
+-			ret = -1;
+ 			goto cleanup;
+ 		}
+ 	}
+@@ -631,7 +636,7 @@ int blk_get_device_part_str(const char *ifname, const char *dev_part_str,
+ 		printf("** Invalid partition type \"%.32s\""
+ 			" (expect \"" BOOT_PART_TYPE "\")\n",
+ 			info->type);
+-		ret  = -1;
++		ret  = -EINVAL;
+ 		goto cleanup;
+ 	}
+ 
+@@ -667,7 +672,7 @@ int part_get_info_by_name_type(struct blk_desc *dev_desc, const char *name,
+ 		}
+ 	}
+ 
+-	return -1;
++	return -ENOENT;
+ }
+ 
+ int part_get_info_by_name(struct blk_desc *dev_desc, const char *name,
+@@ -697,7 +702,7 @@ static int part_get_info_by_dev_and_name(const char *dev_iface,
+ {
+ 	char *ep;
+ 	const char *part_str;
+-	int dev_num;
++	int dev_num, ret;
+ 
+ 	part_str = strchr(dev_part_str, '#');
+ 	if (!part_str || part_str == dev_part_str)
+@@ -713,13 +718,12 @@ static int part_get_info_by_dev_and_name(const char *dev_iface,
+ 	*dev_desc = blk_get_dev(dev_iface, dev_num);
+ 	if (!*dev_desc) {
+ 		printf("Could not find %s %d\n", dev_iface, dev_num);
+-		return -EINVAL;
++		return -ENODEV;
+ 	}
+-	if (part_get_info_by_name(*dev_desc, part_str, part_info) < 0) {
++	ret = part_get_info_by_name(*dev_desc, part_str, part_info);
++	if (ret < 0)
+ 		printf("Could not find \"%s\" partition\n", part_str);
+-		return -EINVAL;
+-	}
+-	return 0;
++	return ret;
+ }
+ 
+ int part_get_info_by_dev_and_name_or_num(const char *dev_iface,
+@@ -727,21 +731,23 @@ int part_get_info_by_dev_and_name_or_num(const char *dev_iface,
+ 					 struct blk_desc **dev_desc,
+ 					 disk_partition_t *part_info)
+ {
++	int ret;
++
+ 	/* Split the part_name if passed as "$dev_num#part_name". */
+-	if (!part_get_info_by_dev_and_name(dev_iface, dev_part_str,
+-					   dev_desc, part_info))
+-		return 0;
++	ret = part_get_info_by_dev_and_name(dev_iface, dev_part_str,
++					    dev_desc, part_info);
++	if (ret >= 0)
++		return ret;
+ 	/*
+ 	 * Couldn't lookup by name, try looking up the partition description
+ 	 * directly.
+ 	 */
+-	if (blk_get_device_part_str(dev_iface, dev_part_str,
+-				    dev_desc, part_info, 1) < 0) {
++	ret = blk_get_device_part_str(dev_iface, dev_part_str,
++				      dev_desc, part_info, 1);
++	if (ret < 0)
+ 		printf("Couldn't find partition %s %s\n",
+ 		       dev_iface, dev_part_str);
+-		return -EINVAL;
+-	}
+-	return 0;
++	return ret;
+ }
+ 
+ void part_set_generic_name(const struct blk_desc *dev_desc,

--- a/recipes-bsp/u-boot/u-boot-imx/0003-Use-partition-labels-in-environment-and-auto-detect-.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/0003-Use-partition-labels-in-environment-and-auto-detect-.patch
@@ -1,0 +1,108 @@
+From f86c9485680d70f4213e3f7b57e0506da3a6ae15 Mon Sep 17 00:00:00 2001
+From: Erik Schumacher <erik.schumacher@iris-sensing.com>
+Date: Tue, 14 Dec 2021 11:53:31 +0100
+Subject: [PATCH] Use partition labels in environment and auto detect mmc
+ partions
+
+---
+ board/freescale/imx8mp_evk/imx8mp_evk.c | 47 +++++++++++++++++++++++++
+ include/configs/imx8mp_evk.h            |  9 ++---
+ 2 files changed, 50 insertions(+), 6 deletions(-)
+
+diff --git a/board/freescale/imx8mp_evk/imx8mp_evk.c b/board/freescale/imx8mp_evk/imx8mp_evk.c
+index 1569c398e9..4c288f60c1 100644
+--- a/board/freescale/imx8mp_evk/imx8mp_evk.c
++++ b/board/freescale/imx8mp_evk/imx8mp_evk.c
+@@ -499,6 +499,52 @@ int board_init(void)
+ 	return 0;
+ }
+ 
++void board_autolocate_boot_partitions(void)
++{
++	/* TODO:
++	   - read bootable flag in GPT, what if no partition is bootable?
++	   - what to do with the changed (and maybe saved) env values?
++	   - what to do, if boot/rootfs not found?
++	*/
++	u32 dev_no = env_get_ulong("emmc_dev", 10, 2);
++	char firmware = 'a'; // assume A for now
++	char mmcroot[32];
++	char partboot[32];
++	char partbootfull[32];
++	char partrootfull[32];
++	disk_partition_t part_info;
++
++	printf("Active firmware: %c - Locating partitions ...\n", firmware);
++
++	sprintf(partboot, "linuxboot_%c", firmware);
++	sprintf(partbootfull, "%d#%s", dev_no, partboot);
++	sprintf(partrootfull, "%d#rootfs_%c", dev_no, firmware);
++	int partnumboot = part_get_info_by_dev_and_name_or_num("mmc", partbootfull, 0, &part_info);
++
++	if (partnumboot < 0) {
++		printf(" !! Could not locate linux boot partition!\n");
++	} else if (!part_info.bootable) {
++		printf(" !! Found linux boot partition, but partition is not marked bootable!\n");
++	} else {
++		printf(" Found linux boot at %d\n", partnumboot);
++	}
++
++	int partnumroot = part_get_info_by_dev_and_name_or_num("mmc", partrootfull, 0, &part_info);
++	if (partnumroot < 0) {
++		printf(" !! Could not locate linux rootfs partition!\n");
++	} else {
++		printf(" Found linux rootfs at %d\n", partnumroot);
++	}
++
++	env_set("mmcpart", partboot);
++	env_set_ulong("mmcdev", dev_no);
++
++	/* Set mmcblk env */
++	sprintf(mmcroot, "/dev/mmcblk%dp%d rootwait rw",
++		mmc_map_to_kernel_blk(dev_no), partnumroot);
++	env_set("mmcroot", mmcroot);
++}
++
+ int board_late_init(void)
+ {
+ #ifdef CONFIG_ENV_IS_IN_MMC
+@@ -509,6 +555,7 @@ int board_late_init(void)
+ 	env_set("board_rev", "iMX8MP");
+ #endif
+ 
++	board_autolocate_boot_partitions();
+ 	return 0;
+ }
+ 
+diff --git a/include/configs/imx8mp_evk.h b/include/configs/imx8mp_evk.h
+index 933dbde5cd..c9872cae75 100644
+--- a/include/configs/imx8mp_evk.h
++++ b/include/configs/imx8mp_evk.h
+@@ -105,15 +105,14 @@
+ 	"initrd_addr=0x43800000\0"		\
+ 	"initrd_high=0xffffffffffffffff\0" \
+ 	"mmcdev="__stringify(CONFIG_SYS_MMC_ENV_DEV)"\0" \
+-	"mmcpart=" __stringify(CONFIG_SYS_MMC_IMG_LOAD_PART) "\0" \
+ 	"mmcroot=" CONFIG_MMCROOT " rootwait rw\0" \
+ 	"mmcautodetect=yes\0" \
+ 	"mmcargs=setenv bootargs ${jh_clk} console=${console} root=${mmcroot}\0 " \
+-	"loadbootscript=fatload mmc ${mmcdev}:${mmcpart} ${loadaddr} ${script};\0" \
++	"loadbootscript=fatload mmc ${mmcdev}#${mmcpart} ${loadaddr} ${script};\0" \
+ 	"bootscript=echo Running bootscript from mmc ...; " \
+ 		"source\0" \
+-	"loadimage=fatload mmc ${mmcdev}:${mmcpart} ${loadaddr} ${image}\0" \
+-	"loadfdt=fatload mmc ${mmcdev}:${mmcpart} ${fdt_addr} ${fdt_file}\0" \
++	"loadimage=fatload mmc ${mmcdev}#${mmcpart} ${loadaddr} ${image}\0" \
++	"loadfdt=fatload mmc ${mmcdev}#${mmcpart} ${fdt_addr} ${fdt_file}\0" \
+ 	"mmcboot=echo Booting from mmc ...; " \
+ 		"run mmcargs; " \
+ 		"if test ${boot_fit} = yes || test ${boot_fit} = try; then " \
+@@ -209,8 +208,6 @@
+ #define CONFIG_SYS_FSL_USDHC_NUM	2
+ #define CONFIG_SYS_FSL_ESDHC_ADDR	0
+ 
+-#define CONFIG_SYS_MMC_IMG_LOAD_PART	1
+-
+ #ifdef CONFIG_FSL_FSPI
+ #define FSL_FSPI_FLASH_SIZE		SZ_32M
+ #define FSL_FSPI_FLASH_NUM		1

--- a/recipes-bsp/u-boot/u-boot-imx_2020.04.bbappend
+++ b/recipes-bsp/u-boot/u-boot-imx_2020.04.bbappend
@@ -3,5 +3,7 @@
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 SRC_URI += "\
-	file://0001-Backport-cmd-fs-Use-part_get_info_by_dev_and_name_or.patch"
-
+	file://0001-Backport-cmd-fs-Use-part_get_info_by_dev_and_name_or.patch\
+	file://0002-Backport-part-Give-several-functions-more-useful-ret.patch\
+	file://0003-Use-partition-labels-in-environment-and-auto-detect-.patch\
+"


### PR DESCRIPTION
Based on #43 (merge that first)

Patch number 3 contains the new U-Boot function `board_autolocate_boot_partitions()` which runs on U-Boot startup. It searches the GPT for the partition labels of the boot and rootfs partition and sets some env values. With this patch, the EVK can automatically boot after flashing via uuu. Though this patch might be touched later when the logic for firmware switching (including watchdog and updates) is implemented.