### PR TITLE
Add mdev.conf to busybox bbappend

### DIFF
--- a/recipes-core/busybox/busybox/mdev.conf
+++ b/recipes-core/busybox/busybox/mdev.conf
@@ -1,0 +1,44 @@
+$MODALIAS=.* 0:0 660 @modprobe "$MODALIAS"
+
+console 0:0 0600 
+cpu_dma_latency 0:0 0660 
+fb0:0 44 0660 
+full 0:0 0666 
+initctl 0:0 0600 
+ircomm[0-9].* 0:20 0660 
+kmem 0:15 0640 
+kmsg 0:0 0660 
+log 0:0 0666 
+loop[0-9].* 0:6 0640 
+mem 0:15 0640 
+network_latency 0:0 0660 
+network_throughput 0:0 0660 
+null 0:0 0666 
+port 0:15 0640 
+ptmx 0:5 0666 
+ram[0-9].* 0:6 0640 
+random 0:0 0666 
+sda 0:6 0640 
+tty 0:5 0666 
+tty.* 0:0 0620 
+urandom 0:0 0666 
+usbdev.* 0:0 0660 */etc/mdev/usb.sh
+vcs.* 0:5 0660 
+zero 0:0 0666 
+ 
+snd/pcm.* 0:0 0660
+snd/control.* 0:0 0660
+snd/timer 0:0 0660
+snd/seq 0:0 0660
+snd/mini.* 0:00 0660
+
+input/event.* 0:0 0660 @/etc/mdev/find-touchscreen.sh
+input/mice 0:0 0660
+input/mouse.* 0:0 0660
+
+tun[0-9]* 0:0 0660 =net/
+
+[hs]d[a-z][0-9]? 0:0 660
+mmcblk[0-9]rpmb 0:0 660
+mmcblk[0-9]boot[0-9] 0:0 660
+mmcblk[0-9].* 0:0 660

--- a/recipes-core/busybox/busybox_%.bbappend
+++ b/recipes-core/busybox/busybox_%.bbappend
@@ -1,6 +1,7 @@
 SRC_URI += "file://fragment.cfg"
 SRC_URI += "file://arp.cfg"
 SRC_URI += "file://ntpd.cfg"
+SRC_URI += "file://mdev.conf"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/busybox:"
 


### PR DESCRIPTION
mdev.conf defines mounting and automount options
mdev.conf is copied from poky layer and the automounting of block
devices (mmcblk, sda, ...) partitions was removed

Mounting block devices on R1 is done via fstab (https://github.com/iris-GmbH/meta-iris-base/blob/develop/recipes-core/base-files/base-files/fstab), the mtd devices would also not match the wildcard used in this config file. This new config file replaces the one from the poky layer that is currently located at _rootfs_/etc/mdev.conf

This change disables automounting on R2, where the emmc partitions match the "mmcblk" wildcard. Mounting on R2 should be done selectively and with limiting permissions.