### PR TITLE
Add swupdate image creation recipe

### DIFF
--- a/recipes-core/images/irma6-base.bb
+++ b/recipes-core/images/irma6-base.bb
@@ -17,7 +17,7 @@ inherit irma6-versioning
 IMAGE_INSTALL_append = " libstdc++ libssl avahi-daemon libavahi-client libavahi-common libavahi-core protobuf-lite zlib yaml-cpp libelf libxml2"
 
 # Include swupdate in image if swupdate is part of the update procedure
-IMAGE_INSTALL_append = " ${@bb.utils.contains('UPDATE_PROCEDURE', 'swupdate', 'swupdate util-linux-sfdisk jq', '', d)}"
+IMAGE_INSTALL_append = " ${@bb.utils.contains('UPDATE_PROCEDURE', 'swupdate', 'swupdate', '', d)}"
 
 # this cannot be done directly in the os-release recipe, due to yocto's buttom-up approach
 # os-release does not know how the final image will be named, as the IMAGE_NAME variable is out of scope

--- a/recipes-support/irma6-swuimage/files/sw-description
+++ b/recipes-support/irma6-swuimage/files/sw-description
@@ -1,0 +1,42 @@
+software =
+{
+        version = "0.1.0";
+        description = "Firmware update for IRMA6 image";
+
+        hardware-compatibility: [ "@@SWU_HW_VERSION@@" ];
+
+                files: (
+                                {
+                                                filename = "@@SWU_KERNEL@@";
+                                                path = "/@@SWU_TARGET_KERNEL@@";
+                                                device = "/dev/swu_kernel";
+                                                filesystem = "vfat";
+                                                version = "@SWU_AUTO_VERSION:kernel";
+                                                properties = {create-destination = "true";}
+                                },
+                                {
+                                                filename = "@@SWU_DEVTREE@@";
+                                                path = "/@@SWU_TARGET_DEVTREE@@";
+                                                device = "/dev/swu_kernel";
+                                                filesystem = "vfat";
+                                                version = "@SWU_AUTO_VERSION:kernel-devicetree";
+                                                properties = {create-destination = "true";}
+                                },
+                );
+
+                images: (
+                                {
+                                                filename = "@@SWU_ROOTFS@@";
+                                                device = "/dev/swu_rootfs";
+                                                version = "@@SWU_VERSION_ROOTFS@@";
+                                                compressed = "zlib";
+                                },
+                );
+
+                scripts: (
+                                {
+                                                filename = "update_firmware.sh";
+                                                type = "shellscript";
+                                },
+                );
+}

--- a/recipes-support/irma6-swuimage/files/update_firmware.sh
+++ b/recipes-support/irma6-swuimage/files/update_firmware.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+
+if [ $# -lt 1 ]; then
+	exit 0;
+fi
+
+EMMC_DEV="/dev/mmcblk2"
+
+get_next_fw() {
+	ROOT_CMD=$(tr ' ' '\n' < /proc/cmdline | grep "^root=")
+	ROOT=$(echo "$ROOT_CMD" | sed -e 's/root=//')
+
+	if [ "$ROOT" = "/dev/nfs" ]; then
+		echo "Detected nfs root; flash firmware a"
+		FW_NEW="a"
+		FW_OLD="b"
+	else
+		ROOTP=$(sfdisk -J $EMMC_DEV | jq 'first(.partitiontable.partitions[] | select (.node == "'"$ROOT"'") | .name)' -r)
+		ROOTF=$(echo "$ROOTP" | sed -e 's/rootfs_//')
+		if [ "$ROOTF" = "a" ]; then
+			FW_NEW="b"
+			FW_OLD="a"
+		else
+			FW_NEW="a"
+			FW_OLD="b"
+		fi
+		echo "Currently on firmware $FW_OLD; flash firmware $FW_NEW"
+	fi
+}
+
+get_fw_devices() {
+	SWU_DEV_ROOTFS=$(sfdisk -J $EMMC_DEV | jq 'first(.partitiontable.partitions[] | select ((.name!=null) and (.name=="rootfs_'$FW_NEW'")) | .node)' -r)
+	SWU_DEV_KERNEL=$(sfdisk -J $EMMC_DEV | jq 'first(.partitiontable.partitions[] | select ((.name!=null) and (.name=="linuxboot_'$FW_NEW'")) | .node)' -r)
+
+	if [ -z "$SWU_DEV_ROOTFS" ]; then
+		echo "Could not locate rootfs partition for firmware $FW_NEW"; exit 10;
+	fi
+	if [ -z "$SWU_DEV_KERNEL" ]; then
+		echo "Could not locate boot partition for firmware $FW_NEW"; exit 10;
+	fi
+}
+
+get_boot_partnum() {
+	BOOT_OLD=$(sfdisk -J $EMMC_DEV | jq 'first(.partitiontable.partitions[] | select ((.name!=null) and (.name=="linuxboot_'$FW_OLD'")) | .node)' -r)
+	BOOT_NEW=$(sfdisk -J $EMMC_DEV | jq 'first(.partitiontable.partitions[] | select ((.name!=null) and (.name=="linuxboot_'$FW_NEW'")) | .node)' -r)
+
+	SWU_BOOTP_OLD=$(echo "$BOOT_OLD" | sed -e "s;$EMMC_DEV.;;")
+	SWU_BOOTP_NEW=$(echo "$BOOT_NEW" | sed -e "s;$EMMC_DEV.;;")
+
+	if [ -z "$SWU_BOOTP_OLD" ]; then
+		echo "Could not locate boot partition for firmware $FW_OLD"; exit 10;
+	fi
+	if [ -z "$SWU_BOOTP_NEW" ]; then
+		echo "Could not locate boot partition for firmware $FW_NEW"; exit 10;
+	fi
+}
+
+if [ "$1" = "preinst" ]; then
+	get_next_fw
+	get_fw_devices
+	ln -sf "$SWU_DEV_KERNEL" /dev/swu_kernel
+	ln -sf "$SWU_DEV_ROOTFS" /dev/swu_rootfs
+fi
+
+if [ "$1" = "postinst" ]; then
+	get_next_fw
+	rm /dev/swu_kernel
+	rm /dev/swu_rootfs
+	get_boot_partnum
+	#TODO: The two calls to sfdisk are not atomic and not failsafe, we need a better way
+	sfdisk --part-attrs $EMMC_DEV "$SWU_BOOTP_NEW" "LegacyBIOSBootable"
+	sfdisk --part-attrs $EMMC_DEV "$SWU_BOOTP_OLD" ""
+	#TODO: Set U-Boot env variables to indicate an update
+fi

--- a/recipes-support/irma6-swuimage/irma6-base-swuimage.bb
+++ b/recipes-support/irma6-swuimage/irma6-base-swuimage.bb
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2022 iris-GmbH infrared & intelligent sensors
+
+require irma6-swuimage.inc
+
+SWU_DEVTREE_imx8mpevk = "imx8mp-evk.dtb"
+SWU_TARGET_DEVTREE_imx8mpevk = "imx8mp-evk.dtb"
+

--- a/recipes-support/irma6-swuimage/irma6-swuimage.inc
+++ b/recipes-support/irma6-swuimage/irma6-swuimage.inc
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2022 iris-GmbH infrared & intelligent sensors
+
+DESCRIPTION = "Generate irma6 swupdate images"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+IMAGENAME = "${@ d.getVar('PN').replace('-swuimage','')}"
+
+# The following line forces the usage of the "files" directory next to this .inc file even if it is required from another layer
+FILESEXTRAPATHS_prepend := "${@os.path.dirname(d.getVar('FILE'))}/files:"
+
+SRC_URI = " \
+    file://sw-description \
+    file://update_firmware.sh \
+"
+
+IMAGE_DEPENDS = "\
+	${IMAGENAME} \
+	virtual/kernel \
+"
+
+SWU_KERNEL = "Image-${MACHINE}.bin"
+SWU_DEVTREE = "${MACHINE}.dtb"
+SWU_ROOTFS = "${IMAGENAME}-${MACHINE}.ext4.gz"
+SWU_META = "${IMAGENAME}-${MACHINE}.testdata.json"
+
+SWU_TARGET_KERNEL = "Image"
+SWU_TARGET_DEVTREE = "${MACHINE}.dtb"
+
+SWU_HW_VERSION = "1.0"
+
+# images and files that will be included in the .swu image
+SWUPDATE_IMAGES = "${SWU_KERNEL} ${SWU_DEVTREE} ${SWU_ROOTFS}"
+
+python() {
+    if "swupdate" not in (d.getVar('UPDATE_PROCEDURE') or ""):
+        raise bb.parse.SkipRecipe('swupdate images can only be build for machines that use this UPDATE_PROCEDURE')
+}
+
+python do_swuimage_prepend () {
+    import json
+    print(d.getVar('IMAGE_LINK_NAME'))
+    # read rootfs / irma6 version from meta file
+    image_dir = d.getVar('DEPLOY_DIR_IMAGE', True)
+    irmameta = json.load(open(os.path.join(image_dir, d.getVar("SWU_META"))))
+    d.setVar("SWU_VERSION_ROOTFS", irmameta['FIRMWARE_VERSION'])
+}
+
+inherit swupdate

--- a/recipes-support/swupdate/swupdate_%.bbappend
+++ b/recipes-support/swupdate/swupdate_%.bbappend
@@ -4,6 +4,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 SRC_URI_append := "file://defconfig"
 
+RDEPENDS_${PN} += "util-linux-sfdisk jq"
 FILES_${PN} += "${SWUPDATE_HW_COMPATIBILITY_FILE}"
 
 do_install_append () {


### PR DESCRIPTION
- inherits swupdate image
- sw-description and shell script based on previous work on VIDA
- check if update procedure matches
- shell script needs sfdisk and jq to operate on GPT partitions

Depends on (draft until both are merged):
- https://github.com/iris-GmbH/meta-iris-base/pull/47
- https://github.com/iris-GmbH/meta-iris-base/pull/48

Create an swuimage by running `bitbake mc:imx8mp-evk:irma6-base-swuimage`. It will build the kernel and the irma6-base image. Test the swuimage by flashing it via a netbooted firmware or on hardware that has been initialized via uuu.