### PR TITLE
Add IRMA6_RELEASE variable to multiconfigs

### DIFF
--- a/conf/multiconfig/imx8mp-evk.conf
+++ b/conf/multiconfig/imx8mp-evk.conf
@@ -6,5 +6,6 @@ IMAGE_FSTYPES = "tar.bz2 \
                  ext4.gz \
                  wic"
 UPDATE_PROCEDURE = "swupdate"
+IRMA6_RELEASE = "2"
 # whitelist mongoose for this config, as the evaluation kit is only used during prototyping: https://www.cesanta.com/license/
 LICENSE_FLAGS_WHITELIST += "commercial_mongoose"

--- a/conf/multiconfig/qemuarm64-r1.conf
+++ b/conf/multiconfig/qemuarm64-r1.conf
@@ -4,6 +4,7 @@
 MACHINE = "qemuarm64"
 PREFERRED_PROVIDER_virtual/bootloader = "u-boot"
 UBOOT_MACHINE ??= "qemu:arm64_defconfig"
+IRMA6_RELEASE = "1"
 # whitelist mongoose for qemuarm64, as it is only used during development: https://cesanta.com/licensing.html
 LICENSE_FLAGS_WHITELIST += "commercial_mongoose"
 IMAGE_ROOTFS_EXTRA_SPACE = "512000"

--- a/conf/multiconfig/qemuarm64-r2.conf
+++ b/conf/multiconfig/qemuarm64-r2.conf
@@ -4,6 +4,7 @@
 MACHINE = "qemuarm64"
 PREFERRED_PROVIDER_virtual/bootloader = "u-boot"
 UBOOT_MACHINE ??= "qemu:arm64_defconfig"
+IRMA6_RELEASE = "2"
 # whitelist mongoose for qemuarm64, as it is only used during development: https://cesanta.com/licensing.html
 LICENSE_FLAGS_WHITELIST += "commercial_mongoose"
 IMAGE_ROOTFS_EXTRA_SPACE = "512000"

--- a/conf/multiconfig/qemux86-64-r1.conf
+++ b/conf/multiconfig/qemux86-64-r1.conf
@@ -3,6 +3,7 @@
 
 MACHINE = "qemux86-64"
 PREFERRED_PROVIDER_virtual/bootloader = "u-boot"
+IRMA6_RELEASE = "1"
 # whitelist mongoose for qemux86, as it is only used during development: https://cesanta.com/licensing.html
 LICENSE_FLAGS_WHITELIST += "commercial_mongoose"
 IMAGE_ROOTFS_EXTRA_SPACE = "512000"

--- a/conf/multiconfig/qemux86-64-r2.conf
+++ b/conf/multiconfig/qemux86-64-r2.conf
@@ -3,6 +3,7 @@
 
 MACHINE = "qemux86-64"
 PREFERRED_PROVIDER_virtual/bootloader = "u-boot"
+IRMA6_RELEASE = "2"
 # whitelist mongoose for qemux86, as it is only used during development: https://cesanta.com/licensing.html
 LICENSE_FLAGS_WHITELIST += "commercial_mongoose"
 IMAGE_ROOTFS_EXTRA_SPACE = "512000"

--- a/conf/multiconfig/sc572-gen6.conf
+++ b/conf/multiconfig/sc572-gen6.conf
@@ -6,5 +6,6 @@ FLASH_FSTYPE ?= "jffs2.sum"
 IMAGE_LINK_NAME = "rootfs"
 FIRMWARE_ZIP_BOOTLOADER_NAME = "u-boot-sc572-gen6.ldr"
 UPDATE_PROCEDURE = "firmwarezip"
+IRMA6_RELEASE = "1"
 # whitelist mongoose for gen6, as it is covered by a commercial product license: http://wiki.iris-sensing.net/display/ESAS/Software-Lizenzen
 LICENSE_FLAGS_WHITELIST += "commercial_mongoose"

--- a/conf/multiconfig/sc573-gen6.conf
+++ b/conf/multiconfig/sc573-gen6.conf
@@ -6,5 +6,6 @@ FLASH_FSTYPE ?= "jffs2.sum"
 IMAGE_LINK_NAME = "rootfs"
 FIRMWARE_ZIP_BOOTLOADER_NAME = "u-boot-sc573-gen6.ldr"
 UPDATE_PROCEDURE = "firmwarezip"
+IRMA6_RELEASE = "1"
 # whitelist mongoose for gen6, as it is covered by a commercial product license: http://wiki.iris-sensing.net/display/ESAS/Software-Lizenzen
 LICENSE_FLAGS_WHITELIST += "commercial_mongoose"


### PR DESCRIPTION
Introduce IRMA6_RELEASE variable that will be propagated into the platform application cmake defines (and could be used to control other things)