### PR TITLE
[RDPHOEN-993] Revert "Make util-linux-sfdisk and jq a dependency of swupdate"

### DIFF
--- a/recipes-core/images/irma6-base.bb
+++ b/recipes-core/images/irma6-base.bb
@@ -17,7 +17,7 @@ inherit irma6-versioning
 IMAGE_INSTALL_append = " libstdc++ libssl avahi-daemon libavahi-client libavahi-common libavahi-core protobuf-lite zlib yaml-cpp libelf libxml2"
 
 # Include swupdate in image if swupdate is part of the update procedure
-IMAGE_INSTALL_append = " ${@bb.utils.contains('UPDATE_PROCEDURE', 'swupdate', 'swupdate', '', d)}"
+IMAGE_INSTALL_append = " ${@bb.utils.contains('UPDATE_PROCEDURE', 'swupdate', 'swupdate util-linux-sfdisk jq', '', d)}"
 
 # this cannot be done directly in the os-release recipe, due to yocto's buttom-up approach
 # os-release does not know how the final image will be named, as the IMAGE_NAME variable is out of scope

--- a/recipes-support/swupdate/swupdate_%.bbappend
+++ b/recipes-support/swupdate/swupdate_%.bbappend
@@ -4,7 +4,6 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 SRC_URI_append := "file://defconfig"
 
-RDEPENDS_${PN} += "util-linux-sfdisk jq"
 FILES_${PN} += "${SWUPDATE_HW_COMPATIBILITY_FILE}"
 
 do_install_append () {


### PR DESCRIPTION
This reverts commit f00d735cd19068e9ea1dbe84069d908a1a0e5630.

Without the revert, other image types, like listed below, do not have
util-linux-sfdisk and jq. This means the update_firmware.sh script fails
during update.

bitbake mc:imx8mp-evk:irma6-base
bitbake mc:imx8mp-evk:irma6-dev
[..]
bitbake mc:imx8mp-evk:irma6-base-uuu
bitbake mc:imx8mp-evk:irma6-dev-uuu
[..]