### PR TITLE
feature/migl/irma6r1_specific_machines

### DIFF
--- a/conf/distro/poky-iris.conf
+++ b/conf/distro/poky-iris.conf
@@ -14,15 +14,6 @@ VIRTUAL-RUNTIME_login_manager = "busybox"
 VIRTUAL-RUNTIME_initscripts = "initscripts"
 VIRTUAL-RUNTIME_keymaps = "keymaps"
 
-# if we want to enable busybox init, we neet to write
-# own startup scripts for e.g. dropbear, networking (ifup, ifdown)
-#VIRTUAL-RUNTIME_init_manager = "busybox"
-#DISTRO_FEATURES_BACKFILL_CONSIDERED += "sysvinit"
-
-#if we want to use a static device table
-#VIRTUAL-RUNTIME_dev_manager = ""
-#USE_DEVFS = "0"
-
 # ldconfig is used to rebuild the /etc/ld.so.cache when new libraries are introduced during runtime
 # this is not needed and /etc/ld.so.cache is already populated by Yocto, disabling this saves ~250kB
 DISTRO_FEATURES_remove = "ldconfig"

--- a/conf/distro/poky-iris.conf
+++ b/conf/distro/poky-iris.conf
@@ -13,7 +13,3 @@ VIRTUAL-RUNTIME_dev_manager = "busybox-mdev"
 VIRTUAL-RUNTIME_login_manager = "busybox"
 VIRTUAL-RUNTIME_initscripts = "initscripts"
 VIRTUAL-RUNTIME_keymaps = "keymaps"
-
-# ldconfig is used to rebuild the /etc/ld.so.cache when new libraries are introduced during runtime
-# this is not needed and /etc/ld.so.cache is already populated by Yocto, disabling this saves ~250kB
-DISTRO_FEATURES_remove = "ldconfig"

--- a/conf/machine/include/sc57x.inc
+++ b/conf/machine/include/sc57x.inc
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2021 iris-GmbH infrared & intelligent sensors
+
+MACHINE_EXTRA_RRECOMMENDS = " kernel-modules kernel-devicetree"
+
+EXTRA_IMAGEDEPENDS += "u-boot"
+
+include conf/machine/include/tune-cortexa5.inc
+DEFAULTTUNE="cortexa5thf-neon"
+
+IMAGE_FSTYPES += "tar.bz2 jffs2 jffs2.sum"
+EXTRA_IMAGECMD_jffs2 = "--little-endian --pad=0x0 --pagesize=0x1000 --eraseblock=0x10000 --squash"
+
+SERIAL_CONSOLE = "115200 ttySC0"
+
+PREFERRED_PROVIDER_virtual/kernel ?= "linux-gen6"
+PREFERRED_PROVIDER_virtual/bootloader = "u-boot-adi"
+PREFERRED_PROVIDER_u-boot = "u-boot-adi"
+
+KERNEL_IMAGETYPE = "uImage-gzip"
+KERNEL_IMAGE_SYMLINK = "uImage"
+KERNEL_DEVICETREE ?= "sc573-gen6.dtb"
+KERNEL_DEVICETREE_SYMLINK = "sc57x-gen6.dtb"
+KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"
+
+UBOOT_SUFFIX = "ldr"
+UBOOT_MACHINE ?= "sc573-gen6_defconfig"
+UBOOT_ENTRYPOINT = "0x82008000"
+UBOOT_LOADADDRESS = "0x82000000"
+
+IMAGE_BOOT_FILES ?= "u-boot.${UBOOT_SUFFIX}"
+
+#Disable rtc in busybox
+MACHINE_FEATURES_BACKFILL_CONSIDERED = "rtc"
+
+BOARD ?= "sc573-gen6"

--- a/conf/machine/include/sc57x.inc
+++ b/conf/machine/include/sc57x.inc
@@ -36,3 +36,7 @@ IMAGE_BOOT_FILES ?= "u-boot.${UBOOT_SUFFIX}"
 MACHINE_FEATURES_BACKFILL_CONSIDERED = "rtc"
 
 BOARD ?= "sc573-gen6"
+
+# ldconfig is used to rebuild the /etc/ld.so.cache when new libraries are introduced during runtime
+# this is not needed and /etc/ld.so.cache is already populated by Yocto, disabling this saves ~250kB
+DISTRO_FEATURES_remove += "ldconfig"

--- a/conf/machine/include/sc57x.inc
+++ b/conf/machine/include/sc57x.inc
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2021 iris-GmbH infrared & intelligent sensors
 
+MACHINEOVERRIDES =. "sc57x:"
+
 MACHINE_EXTRA_RRECOMMENDS = " kernel-modules kernel-devicetree"
 
 EXTRA_IMAGEDEPENDS += "u-boot"

--- a/conf/machine/sc572-gen6.conf
+++ b/conf/machine/sc572-gen6.conf
@@ -6,37 +6,8 @@
 
 #@DESCRIPTION: Machine configuration for Generation 6 platform with sc572 cpu
 
+require conf/machine/include/sc57x.inc
 
-MACHINE_EXTRA_RRECOMMENDS = " kernel-modules kernel-devicetree"
-
-EXTRA_IMAGEDEPENDS += "u-boot"
-
-include conf/machine/include/tune-cortexa5.inc
-DEFAULTTUNE="cortexa5thf-neon"
-
-IMAGE_FSTYPES += "tar.bz2 jffs2 jffs2.sum"
-EXTRA_IMAGECMD_jffs2 = "--little-endian --pad=0x0 --pagesize=0x1000 --eraseblock=0x10000 --squash"
-
-SERIAL_CONSOLE = "115200 ttySC0"
-
-PREFERRED_PROVIDER_virtual/kernel ?= "linux-gen6"
-PREFERRED_PROVIDER_virtual/bootloader = "u-boot-adi"
-PREFERRED_PROVIDER_u-boot = "u-boot-adi"
-
-KERNEL_IMAGETYPE = "uImage-gzip"
-KERNEL_IMAGE_SYMLINK = "uImage"
 KERNEL_DEVICETREE = "sc572-gen6.dtb"
-KERNEL_DEVICETREE_SYMLINK = "sc57x-gen6.dtb"
-KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"
-
-UBOOT_SUFFIX = "ldr"
 UBOOT_MACHINE = "sc572-gen6_defconfig"
-UBOOT_ENTRYPOINT = "0x82008000"
-UBOOT_LOADADDRESS = "0x82000000"
-
-IMAGE_BOOT_FILES ?= "u-boot.${UBOOT_SUFFIX}"
-
-#Disable rtc in busybox
-MACHINE_FEATURES_BACKFILL_CONSIDERED = "rtc"
-
 BOARD = "sc572-gen6"

--- a/conf/machine/sc573-gen6-4dvein.conf
+++ b/conf/machine/sc573-gen6-4dvein.conf
@@ -6,37 +6,6 @@
 
 #@DESCRIPTION: Machine configuration for Generation 6 platform with sc573 cpu (4dvein configuration)
 
-
-MACHINE_EXTRA_RRECOMMENDS = " kernel-modules kernel-devicetree"
-
-EXTRA_IMAGEDEPENDS += "u-boot"
-
-include conf/machine/include/tune-cortexa5.inc
-DEFAULTTUNE="cortexa5thf-neon"
-
-IMAGE_FSTYPES += "tar.bz2 jffs2 jffs2.sum"
-EXTRA_IMAGECMD_jffs2 = "--little-endian --pad=0x0 --pagesize=0x1000 --eraseblock=0x10000 --squash"
-
-SERIAL_CONSOLE = "115200 ttySC0"
-
-PREFERRED_PROVIDER_virtual/kernel ?= "linux-gen6"
-PREFERRED_PROVIDER_virtual/bootloader = "u-boot-adi"
-PREFERRED_PROVIDER_u-boot = "u-boot-adi"
-
-KERNEL_IMAGETYPE = "uImage-gzip"
-KERNEL_IMAGE_SYMLINK = "uImage"
-KERNEL_DEVICETREE = "sc573-gen6.dtb"
-KERNEL_DEVICETREE_SYMLINK = "sc57x-gen6.dtb"
-KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"
-
-UBOOT_SUFFIX = "ldr"
-UBOOT_MACHINE = "sc573-gen6_defconfig"
-UBOOT_ENTRYPOINT = "0x82008000"
-UBOOT_LOADADDRESS = "0x82000000"
-
-IMAGE_BOOT_FILES ?= "u-boot.${UBOOT_SUFFIX}"
-
-#Disable rtc in busybox
-MACHINE_FEATURES_BACKFILL_CONSIDERED = "rtc"
+require conf/machine/include/sc57x.inc
 
 BOARD = "sc573-gen6-4dvein"

--- a/conf/machine/sc573-gen6.conf
+++ b/conf/machine/sc573-gen6.conf
@@ -6,37 +6,6 @@
 
 #@DESCRIPTION: Machine configuration for Generation 6 platform with sc573 cpu
 
-
-MACHINE_EXTRA_RRECOMMENDS = " kernel-modules kernel-devicetree"
-
-EXTRA_IMAGEDEPENDS += "u-boot"
-
-include conf/machine/include/tune-cortexa5.inc
-DEFAULTTUNE="cortexa5thf-neon"
-
-IMAGE_FSTYPES += "tar.bz2 jffs2 jffs2.sum"
-EXTRA_IMAGECMD_jffs2 = "--little-endian --pad=0x0 --pagesize=0x1000 --eraseblock=0x10000 --squash"
-
-SERIAL_CONSOLE = "115200 ttySC0"
-
-PREFERRED_PROVIDER_virtual/kernel ?= "linux-gen6"
-PREFERRED_PROVIDER_virtual/bootloader = "u-boot-adi"
-PREFERRED_PROVIDER_u-boot = "u-boot-adi"
-
-KERNEL_IMAGETYPE = "uImage-gzip"
-KERNEL_IMAGE_SYMLINK = "uImage"
-KERNEL_DEVICETREE = "sc573-gen6.dtb"
-KERNEL_DEVICETREE_SYMLINK = "sc57x-gen6.dtb"
-KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"
-
-UBOOT_SUFFIX = "ldr"
-UBOOT_MACHINE = "sc573-gen6_defconfig"
-UBOOT_ENTRYPOINT = "0x82008000"
-UBOOT_LOADADDRESS = "0x82000000"
-
-IMAGE_BOOT_FILES ?= "u-boot.${UBOOT_SUFFIX}"
-
-#Disable rtc in busybox
-MACHINE_FEATURES_BACKFILL_CONSIDERED = "rtc"
+require conf/machine/include/sc57x.inc
 
 BOARD = "sc573-gen6"


### PR DESCRIPTION
- We can now address IRMA6 Release 1 (Gen6) things (packages/tools /variables) in recipes via a common machine -> sc57x
- `ldconfig` was removed from Release 1 due to space constraints, but should be added again for Release 2