### PR TITLE
linux-fslc-iris: Add patch to fix fsl-dsp devicetree node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [APR's Version Numbering](https://apr.apache.org/ver
 
 ### Fixed
 - [RDPHOEN-1013]: Fix setting the format on the Serializer, enables switching between Raw12 and Raw14 formats without setting the format twice
+- [RDPHOEN-1150]: Fix fsl-dsp devicetree node in linux-fslc, place reserved memory region inside RAM bounds
 
 
 ### Simulation only

--- a/recipes-kernel/linux/linux-fslc-iris.inc
+++ b/recipes-kernel/linux/linux-fslc-iris.inc
@@ -37,6 +37,7 @@ SRC_URI += " \
     file://0029-imx8mp-irma6r2.dts-Disable-eqos-and-fec-ethernet-nod.patch \
     file://0030-imx8mp-irma6r2.dts-Set-DRAM-size-to-1x512MiB.patch \
     file://0031-tc358746.c-Reset-when-changing-format.patch \
+    file://0032-imx8mp-irma6r2.dts-Change-memory-range-for-dsp.patch \
 "
 
 KERNEL_DEFCONFIG_imx8mpevk = "imx8mp-evk-r2_defconfig"

--- a/recipes-kernel/linux/linux-fslc-iris/0032-imx8mp-irma6r2.dts-Change-memory-range-for-dsp.patch
+++ b/recipes-kernel/linux/linux-fslc-iris/0032-imx8mp-irma6r2.dts-Change-memory-range-for-dsp.patch
@@ -1,0 +1,31 @@
+From c4dc9ddb461a920ad1c115e026652833fc94b830 Mon Sep 17 00:00:00 2001
+From: Erik Schumacher <erik.schumacher@iris-sensing.com>
+Date: Fri, 6 May 2022 10:39:56 +0200
+Subject: [PATCH] imx8mp-irma6r2.dts: Change memory range for dsp
+
+Move dsp reserved memory into RAM bounds
+Fixes kernel panic when booting a fit image
+
+Signed-off-by: Erik Schumacher <erik.schumacher@iris-sensing.com>
+---
+ arch/arm64/boot/dts/freescale/imx8mp-irma6r2.dts | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/freescale/imx8mp-irma6r2.dts b/arch/arm64/boot/dts/freescale/imx8mp-irma6r2.dts
+index b16055d99eff..388a0a2c8469 100644
+--- a/arch/arm64/boot/dts/freescale/imx8mp-irma6r2.dts
++++ b/arch/arm64/boot/dts/freescale/imx8mp-irma6r2.dts
+@@ -96,6 +96,10 @@
+ 	};
+ };
+ 
++&dsp_reserved {
++	reg = <0 0x5C000000 0 0x2000000>;
++};
++
+ &clk {
+ 	init-on-array = <IMX8MP_CLK_HSIO_ROOT>;
+ };
+-- 
+2.34.1
+


### PR DESCRIPTION
With some setups (e.g. with fit images), the kernel could not boot.

dsp_reserved, as defined in imx8mp.dtsi, was located outside the DRAM bounds and led to a kernel panic.