### PR TITLE
[RDPHOEN-958] Add patches for removing CONFIG_CMD_BOOTEFI

### DIFF
--- a/recipes-bsp/u-boot/u-boot-imx/imx8mp-irma6r2/0015-RDPHOEN-958-Remove-CONFIG_CMD_BOOTEFI-for-imx8mp_irm.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/imx8mp-irma6r2/0015-RDPHOEN-958-Remove-CONFIG_CMD_BOOTEFI-for-imx8mp_irm.patch
@@ -1,0 +1,27 @@
+From f38a23ed9025bc5c7041749cc79ecc3d721ae5e8 Mon Sep 17 00:00:00 2001
+From: "Jan.Hannig" <jan.hannig@irisgmbh.de>
+Date: Tue, 10 May 2022 13:32:01 +0200
+Subject: [PATCH 15/16] [RDPHOEN-958] Remove CONFIG_CMD_BOOTEFI for
+ imx8mp_irma6r2_defconfig
+
+As the function "efi_set_bootdev" called within this compiler switch
+causes the error msg "**Bad device specification mmc 2#linuxboot_a **".
+---
+ configs/imx8mp_irma6r2_defconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/configs/imx8mp_irma6r2_defconfig b/configs/imx8mp_irma6r2_defconfig
+index e4333589b4..1dc7fa61b3 100644
+--- a/configs/imx8mp_irma6r2_defconfig
++++ b/configs/imx8mp_irma6r2_defconfig
+@@ -40,6 +40,7 @@ CONFIG_SPL_POWER_SUPPORT=y
+ CONFIG_HUSH_PARSER=y
+ CONFIG_SYS_PROMPT="u-boot=> "
+ # CONFIG_BOOTM_NETBSD is not set
++# CONFIG_CMD_BOOTEFI is not set
+ # CONFIG_CMD_EXPORTENV is not set
+ # CONFIG_CMD_IMPORTENV is not set
+ CONFIG_CMD_ERASEENV=y
+-- 
+2.20.1
+

--- a/recipes-bsp/u-boot/u-boot-imx/imx8mpevk/0003-RDPHOEN-958-Remove-CONFIG_CMD_BOOTEFI-for-imx8mp_evk.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/imx8mpevk/0003-RDPHOEN-958-Remove-CONFIG_CMD_BOOTEFI-for-imx8mp_evk.patch
@@ -1,0 +1,27 @@
+From b717dc7a1b4a37f9a4f48d6a9ee75fadac551e71 Mon Sep 17 00:00:00 2001
+From: "Jan.Hannig" <jan.hannig@irisgmbh.de>
+Date: Tue, 10 May 2022 13:37:04 +0200
+Subject: [PATCH 16/16] [RDPHOEN-958] Remove CONFIG_CMD_BOOTEFI for
+ imx8mp_evk_defconfig
+
+As the function "efi_set_bootdev" called within this compiler switch
+causes the error msg "**Bad device specification mmc 2#linuxboot_a **".
+---
+ configs/imx8mp_evk_defconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/configs/imx8mp_evk_defconfig b/configs/imx8mp_evk_defconfig
+index 82d1281f5b..0198e0beeb 100644
+--- a/configs/imx8mp_evk_defconfig
++++ b/configs/imx8mp_evk_defconfig
+@@ -43,6 +43,7 @@ CONFIG_SYS_PROMPT="u-boot=> "
+ # CONFIG_CMD_IMPORTENV is not set
+ CONFIG_CMD_ERASEENV=y
+ # CONFIG_CMD_CRC32 is not set
++# CONFIG_CMD_BOOTEFI is not set
+ # CONFIG_BOOTM_NETBSD is not set
+ CONFIG_CMD_CLK=y
+ CONFIG_CMD_FUSE=y
+-- 
+2.20.1
+

--- a/recipes-bsp/u-boot/u-boot-imx_iris.inc
+++ b/recipes-bsp/u-boot/u-boot-imx_iris.inc
@@ -11,6 +11,7 @@ FILESEXTRAPATHS_prepend_imx8mpevk := "${THISDIR}/u-boot-imx/imx8mpevk:"
 SRC_URI_append_imx8mpevk = "\
 	file://0001-Use-partition-labels-in-environment-and-auto-detect-.patch\
 	file://0002-Enable-Secure-Boot-HAB-on-imx8mp-evk.patch \
+    file://0003-RDPHOEN-958-Remove-CONFIG_CMD_BOOTEFI-for-imx8mp_evk.patch \
 "
 
 FILESEXTRAPATHS_prepend_imx8mp-irma6r2 := "${THISDIR}/u-boot-imx/imx8mp-irma6r2:"
@@ -29,4 +30,5 @@ SRC_URI_append_imx8mp-irma6r2 = "\
 	file://0012-Setup-eqos-for-RMII.patch \
 	file://0013-Use-partition-labels-in-environment-and-auto-detect-.patch \
 	file://0014-Enable-Secure-Boot-HAB-on-imx8mp-irma6r2.patch \
+	file://0015-RDPHOEN-958-Remove-CONFIG_CMD_BOOTEFI-for-imx8mp_irm.patch \
 "


### PR DESCRIPTION
for imx8mpevk and imx8mp-irma6r2,
as the function "efi_set_bootdev" called within this compiler switch
causes the error msg "**Bad device specification mmc 2#linuxboot_a **".