### PR TITLE
imx-boot: Sign the booable image imx-boot (flash.bin)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [APR's Version Numbering](https://apr.apache.org/ver
 - [APC-4501] Added backport of chrony recipe for NTS support introduced with v4.0
 - [APC-4244]: Add nginx and sqlite3 as required by the new password protection of the webinterface
 - [RDPHOEN-1083]: Add HAB support on imx8, enable and switch to fit image boot
+- [RDPHOEN-1083]: Sign bootable image: imx-boot.signed
 
 
 ### Changed

--- a/recipes-bsp/imx-mkimage/files/0001-Fix-cleanup-Remove-device-tree-deletion-after-make.patch
+++ b/recipes-bsp/imx-mkimage/files/0001-Fix-cleanup-Remove-device-tree-deletion-after-make.patch
@@ -1,0 +1,29 @@
+From f728de0bfee95f26ebf4a2e8164a69938a697ce8 Mon Sep 17 00:00:00 2001
+From: Michael Glembotzki <Michael.Glembotzki@iris-sensing.com>
+Date: Thu, 12 May 2022 15:17:15 +0200
+Subject: [PATCH] Fix cleanup: Remove device tree deletion after make
+
+The device tree is deleted after processing. This is problematic because the
+temporary name is identical to the default name.
+
+Signed-off-by: Michael Glembotzki <Michael.Glembotzki@iris-sensing.com>
+---
+ iMX8M/soc.mak | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/iMX8M/soc.mak b/iMX8M/soc.mak
+index 4e23da8..0df22dd 100644
+--- a/iMX8M/soc.mak
++++ b/iMX8M/soc.mak
+@@ -156,7 +156,7 @@ u-boot.itb: $(dtbs)
+ 	./$(PAD_IMAGE) u-boot-nodtb.bin $(dtbs)
+ 	DEK_BLOB_LOAD_ADDR=$(DEK_BLOB_LOAD_ADDR) TEE_LOAD_ADDR=$(TEE_LOAD_ADDR) ATF_LOAD_ADDR=$(ATF_LOAD_ADDR) ./mkimage_fit_atf.sh $(dtbs) > u-boot.its
+ 	./mkimage_uboot -E -p 0x3000 -f u-boot.its u-boot.itb
+-	@rm -f u-boot.its $(dtbs)
++	@rm -f u-boot.its
+ 
+ dtbs_ddr3l = valddr3l.dtb
+ $(dtbs_ddr3l):
+-- 
+2.35.1
+

--- a/recipes-bsp/imx-mkimage/imx-boot_%.bbappend
+++ b/recipes-bsp/imx-mkimage/imx-boot_%.bbappend
@@ -2,6 +2,225 @@
 # Copyright (C) 2022 iris-GmbH infrared & intelligent sensors
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
-SRC_URI_append_imx8mp-irma6r2 = " file://0001-Add-imx8mp-irma6r2-SOC-based-on-imx8mp-with-DDR4-fir.patch"
+SRC_URI_append_imx8mp-irma6r2 = " \
+    file://0001-Add-imx8mp-irma6r2-SOC-based-on-imx8mp-with-DDR4-fir.patch \
+"
+SRC_URI_append = " \
+    file://0001-Fix-cleanup-Remove-device-tree-deletion-after-make.patch \
+"
 
 SOC_TARGET_imx8mp-irma6r2 = "iMX8MPI6R2"
+
+python __anonymous () {
+    if d.getVar('HAB_ENABLE', True):
+        d.appendVar("DEPENDS", " cst-native")
+}
+
+hex2dec() {
+    echo $(printf '%d' $1)
+}
+
+#
+# do_compile must be overwritten because the "make" outputs are required for
+# the further signature process. The outputs are stored in the files
+# hab_info1.txt and hab_info2.txt.
+#
+do_compile() {
+    # mkimage for i.MX8
+    # Copy TEE binary to SoC target folder to mkimage
+    if ${DEPLOY_OPTEE}; then
+        cp ${DEPLOY_DIR_IMAGE}/tee.bin ${BOOT_STAGING}
+    fi
+    for target in ${IMXBOOT_TARGETS}; do
+        compile_${SOC_FAMILY}
+        if [ "$target" = "flash_linux_m4_no_v2x" ]; then
+            # Special target build for i.MX 8DXL with V2X off
+            bbnote "building ${SOC_TARGET} - ${REV_OPTION} V2X=NO ${target}"
+            make SOC=${SOC_TARGET} ${REV_OPTION} V2X=NO dtbs=${UBOOT_DTB_NAME} flash_linux_m4
+        else
+            bbnote "building ${SOC_TARGET} - ${REV_OPTION} ${target}"
+            make SOC=${SOC_TARGET} ${REV_OPTION} dtbs=${UBOOT_DTB_NAME} ${target} > ${S}/hab_info1.txt 2>&1
+        fi
+
+        if [ "${HAB_ENABLE}" = "1" ];then
+            case ${SOC_TARGET} in
+              "iMX8MPI6R2")
+                print_cmd=print_fit_hab_ddr4
+                ;;
+              "iMX8MP")
+                print_cmd=print_fit_hab
+                ;;
+              *)
+                bberror "HAB signing is not supported yet for ${SOC_TARGET}!"
+                ;;
+            esac
+            make SOC=${SOC_TARGET} $print_cmd > ${S}/hab_info2.txt
+        fi
+
+        if [ -e "${BOOT_STAGING}/flash.bin" ]; then
+            cp ${BOOT_STAGING}/flash.bin ${S}/${BOOT_CONFIG_MACHINE}-${target}
+        fi
+    done
+}
+
+#
+# Emit the CSF File for SPL part
+#
+# $1 ... CSF SPL Filename
+# $2 ... SRK Table Binary
+# $3 ... CSF Key File
+# $4 ... Image Key File
+# $5 ... Block Data
+# $6 ... CAAM / DCP
+csf_emit_spl_file() {
+	cat << EOF > ${1}
+[Header]
+Version = 4.5
+Hash Algorithm = sha256
+Engine Configuration = 0
+Certificate Format = X509
+Signature Format = CMS
+Engine = ${6}
+
+[Install SRK]
+File = "${2}"
+Source index = 0
+
+[Install CSFK]
+File = "${3}"
+
+[Authenticate CSF]
+
+[Unlock]
+Engine = ${6}
+Features = MID
+
+[Unlock]
+Engine = ${6}
+Features = MFG
+
+[Install Key]
+Verification index = 0
+Target index = 2
+File = "${4}"
+
+[Authenticate Data]
+Verification index = 2
+Blocks = ${5}
+
+EOF
+}
+
+#
+# Emit the CSF File for FIT part
+#
+# $1 ... CSF FIT Filename
+# $2 ... SRK Table Binary
+# $3 ... CSF Key File
+# $4 ... Image Key File
+# $5 ... Block Data
+# $6 ... CAAM / DCP
+csf_emit_fit_file() {
+	cat << EOF > ${1}
+[Header]
+Version = 4.5
+Hash Algorithm = sha256
+Engine = ${6}
+Engine Configuration = 0
+Certificate Format = X509
+Signature Format = CMS
+
+[Install SRK]
+File = "${2}"
+Source index = 0
+
+[Install CSFK]
+File = "${3}"
+
+[Authenticate CSF]
+
+[Unlock]
+Engine = ${6}
+Features = MID
+
+[Unlock]
+Engine = ${6}
+Features = MFG
+
+[Install Key]
+Verification index = 0
+Target index = 2
+File = "${4}"
+
+[Authenticate Data]
+Verification index = 2
+Blocks = ${5}
+
+EOF
+}
+
+set_imxboot_target() {
+    for target in ${IMXBOOT_TARGETS}; do
+        # Use first "target" as IMAGE_IMXBOOT_TARGET
+        if [ "$IMAGE_IMXBOOT_TARGET" = "" ]; then
+	        IMAGE_IMXBOOT_TARGET="$target"
+        fi
+    done
+}
+
+sign_uboot_common() {
+    # Copy flash.bin
+    set_imxboot_target
+    fn="${S}/${BOOT_CONFIG_MACHINE}-${IMAGE_IMXBOOT_TARGET}.signed"
+    cp ${S}/${BOOT_CONFIG_MACHINE}-${IMAGE_IMXBOOT_TARGET} ${fn}
+
+    # Parse hab signing info (offset, blocks) 
+    cst_off=$(cat ${S}/hab_info1.txt | grep -w csf_off | cut -f3)
+    cst_off=$(hex2dec $cst_off)
+    sld_csf_off=$(cat ${S}/hab_info1.txt | grep -w sld_csf_off | cut -f3)
+    sld_csf_off=$(hex2dec $sld_csf_off)
+    blocks_spl="$(cat ${S}/hab_info1.txt | grep -w "spl hab block" | cut -f2) \"${fn}\""
+    blocks_fit1="$(cat ${S}/hab_info1.txt | grep -w "sld hab block" | cut -f2) \"${fn}\", \\"
+    blocks_fit2="$(cat ${S}/hab_info2.txt | tail -n 4 | while read line; do echo "$line \"${fn}\", \\"; done)"
+    blocks_fit=$(printf '%s\n%s' "$blocks_fit1" "${blocks_fit2%???}")
+
+    # Create csf_spl.txt and csf_fit.txt
+    csf_emit_spl_file "${S}/csf_spl.txt" "${SRKTAB}" "${CSFK}" "${SIGN_CERT}" "${blocks_spl}" "${CRYPTO_HW_ACCEL}"
+    csf_emit_fit_file "${S}/csf_fit.txt" "${SRKTAB}" "${CSFK}" "${SIGN_CERT}" "${blocks_fit}" "${CRYPTO_HW_ACCEL}"
+
+    # Create csf files
+    cst -i ${S}/csf_spl.txt -o ${S}/csf_spl.bin
+    cst -i ${S}/csf_fit.txt -o ${S}/csf_fit.bin
+
+    # Sign bootable image
+    dd if=${S}/csf_spl.bin of=$fn seek=$cst_off bs=1 conv=notrunc
+    dd if=${S}/csf_fit.bin of=$fn seek=$sld_csf_off bs=1 conv=notrunc
+}
+
+do_sign_uboot() {
+    if [ "${HAB_ENABLE}" = "1" ];then
+        sign_uboot_common
+    else
+        bbwarn "HAB boot not enabled."
+    fi
+}
+
+do_install_append() {
+    if [ "${HAB_ENABLE}" = "1" ];then
+        set_imxboot_target
+        install -m 0644 ${S}/${BOOT_CONFIG_MACHINE}-${IMAGE_IMXBOOT_TARGET}.signed ${D}/boot/
+    fi
+}
+
+do_deploy_append() {
+    if [ "${HAB_ENABLE}" = "1" ];then
+        # copy flash.bin.signed to deploy dir and create a symlink imx-boot.signed
+        set_imxboot_target
+        install -m 0644 ${S}/${BOOT_CONFIG_MACHINE}-${IMAGE_IMXBOOT_TARGET}.signed ${DEPLOYDIR}
+        cd ${DEPLOYDIR}
+        ln -sf ${BOOT_CONFIG_MACHINE}-${IMAGE_IMXBOOT_TARGET}.signed ${BOOT_NAME}.signed
+        cd -
+    fi
+}
+
+addtask do_sign_uboot before do_deploy after do_compile


### PR DESCRIPTION
Pimp the imx-mkimage tool so that the generated bootable image (flash.bin) is
automatically signed. In addition to the bootable image imx-boot (aka.
flash.bin), a signed variant named imx-boot.signed is now being built.

Please make sure that the following parameters are set for the build process:

```
    HAB_ENABLE = "1"
    HAB_DIR = "/mnt/yocto-kas/dev_keys"
    SRKTAB = "${HAB_DIR}/crts/SRK_1_2_3_4_table.bin"
    CSFK = "${HAB_DIR}/crts/CSF1_1_sha256_secp521r1_v3_usr_crt.pem"
    SIGN_CERT = "${HAB_DIR}/crts/IMG1_1_sha256_secp521r1_v3_usr_crt.pem"
    CRYPTO_HW_ACCEL = "CAAM"
```

**How to build?**
```
# kas-irma6-base.yml: meta-iris-base: set refspec: "feature/migl/RDPHOEN-1124-sign_bootable_image"
$ USER_ID=$(id -u) GROUP_ID=$(id -g) SSH_DIR=~/.ssh_yocto docker-compose run --service-ports --rm kas shell kas-irma6-pa.yml:include/kas-irma6-imx8mp-irma6r2.yml

$ bitbake mc:imx8mp-irma6r2:imx-boot
$ bitbake mc:imx8mp-irma6r2:irma6-dev

.
├── imx-boot-imx8mp-irma6r2-sd.bin-flash_ddr4_evk
├── imx-boot -> imx-boot-imx8mp-irma6r2-sd.bin-flash_ddr4_evk
├── imx-boot-imx8mp-irma6r2-sd.bin-flash_ddr4_evk.signed
└── imx-boot.signed -> imx-boot-imx8mp-irma6r2-sd.bin-flash_ddr4_evk.signed

# Alternatively the imx8mp-evk also works:
$ bitbake mc:imx8mp-evk:imx-boot
$ bitbake mc:imx8mp-evk:irma6-dev
```

**How to flash the emmc?**
`$ uuu -b emmc  imx-boot.signed`

**How can it be tested whether the signature check works or whether the flash.bin is signed at all?**
No HAB events should be fired when starting the bootable image. This can be checked in u-boot for boards that have not yet been closed as follows:
```
u-boot=>   hab_status                                                                                                                              
                                                                                                                                                   
Secure boot disabled                                                                                                                               
                                                                                                                                                   
HAB Configuration: 0xf0, HAB State: 0x66                                                                                                           
No HAB Events Found!
```