### PR TITLE
Feature/ersc/rdphoen 1142 signed fit images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [APR's Version Numbering](https://apr.apache.org/ver
 - [APC-4244]: Add nginx and sqlite3 as required by the new password protection of the webinterface
 - [RDPHOEN-1083]: Add HAB support on imx8, enable and switch to fit image boot
 - [RDPHOEN-1083]: Sign bootable image: imx-boot.signed
+- [RDPHOEN-1142]: Add signing and fitimage configuration and recipes for irma6 fitimages
 
 
 ### Changed

--- a/classes/irma6-signing-variable-check.bbclass
+++ b/classes/irma6-signing-variable-check.bbclass
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2022 iris-GmbH infrared & intelligent sensors
+
+do_signing_variable_check() {
+	if [ -z "${CRYPTO_HW_ACCEL}" ]; then
+		bbwarn "CRYPTO_HW_ACCEL is not set"
+	fi
+
+	if [ -z "${SIGN_CERT}" ]; then
+		bbwarn "SIGN_CERT is not set"
+	fi
+
+	if [ -z "${CSFK}" ]; then
+		bbwarn "CSFK is not set"
+	fi
+
+	if [ -z "${SRKTAB}" ]; then
+		bbwarn "SRKTAB is not set"
+	fi
+}

--- a/conf/machine/imx8mp-irma6r2.conf
+++ b/conf/machine/imx8mp-irma6r2.conf
@@ -50,3 +50,4 @@ IMX_BOOT_SEEK = "32"
 
 OPTEE_BIN_EXT = "8mp"
 
+KERNEL_IMAGETYPE_aarch64 = "Image.gz"

--- a/recipes-core/images/crypt-image-initramfs.bbappend
+++ b/recipes-core/images/crypt-image-initramfs.bbappend
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2022 iris-GmbH infrared & intelligent sensors
+
+INITRAMFS_COMMON_PACKAGES = " \
+			  initramfs-init \
+			  base-files \
+			  udev \
+			  base-passwd \
+			  lvm2 \
+			  ${VIRTUAL-RUNTIME_base-utils} \
+			  ${ROOTFS_BOOTSTRAP_INSTALL} \
+"
+
+PACKAGE_INSTALL = "${INITRAMFS_COMMON_PACKAGES}"

--- a/recipes-core/images/files/rescue.its.in
+++ b/recipes-core/images/files/rescue.its.in
@@ -1,22 +1,22 @@
 /dts-v1/;
 
 / {
-	description = "Rescue Image for MACHINE board";
-	version = "RES_RESCUE_RUNNING_VERSION";
+	description = "FITIMAGE_DESCRIPTION for MACHINE board";
+	version = "FITIMAGE_RUNNING_VERSION";
 	#address-cells = <1>;
 
 	images {
 		kernel@1 {
 			description = "Linux kernel";
-			data = /incbin/("DEPLOY_DIR_IMAGE/fitImage-linux.bin-MACHINE");
+			data = /incbin/("DEPLOY_DIR_IMAGE/KERNEL_IMAGETYPE");
 			type = "kernel";
 			arch = "TARGET_ARCH";
 			os = "linux";
-			compression = "none";
+			compression = "KERNEL_COMPRESSION";
 			load = <ITS_KERNEL_LOAD_ADDR>;
 			entry = <ITS_KERNEL_ENTRY_ADDR>;
 			hash@1 {
-				algo = "sha1";
+				algo = "sha256";
 			};
 		};
 		fdt@1 {
@@ -25,8 +25,10 @@
 			type = "flat_dt";
 			arch = "TARGET_ARCH";
 			compression = "none";
+			load = <0x43000000>;
+			entry = <0x43000000>;
 			hash@1 {
-				algo = "sha1";
+				algo = "sha256";
 			};
 		};
 		ramdisk@1 {
@@ -38,7 +40,7 @@
 			compression = "none";
 
 			hash@1 {
-				algo = "sha1";
+				algo = "sha256";
 			};
 		};
 	};
@@ -52,7 +54,7 @@
 			ramdisk = "ramdisk@1";
 
 			hash@1 {
-				algo = "sha1";
+				algo = "sha256";
 			};
 		};
 	};

--- a/recipes-core/images/files/rescue.its.in
+++ b/recipes-core/images/files/rescue.its.in
@@ -1,0 +1,59 @@
+/dts-v1/;
+
+/ {
+	description = "Rescue Image for MACHINE board";
+	version = "RES_RESCUE_RUNNING_VERSION";
+	#address-cells = <1>;
+
+	images {
+		kernel@1 {
+			description = "Linux kernel";
+			data = /incbin/("DEPLOY_DIR_IMAGE/fitImage-linux.bin-MACHINE");
+			type = "kernel";
+			arch = "TARGET_ARCH";
+			os = "linux";
+			compression = "none";
+			load = <ITS_KERNEL_LOAD_ADDR>;
+			entry = <ITS_KERNEL_ENTRY_ADDR>;
+			hash@1 {
+				algo = "sha1";
+			};
+		};
+		fdt@1 {
+			description = "Flattened Device Tree blob";
+			data = /incbin/("DEPLOY_DIR_IMAGE/KERNEL_DEVICETREE");
+			type = "flat_dt";
+			arch = "TARGET_ARCH";
+			compression = "none";
+			hash@1 {
+				algo = "sha1";
+			};
+		};
+		ramdisk@1 {
+			description = "image-initramfs";
+			data = /incbin/("DEPLOY_DIR_IMAGE/RESCUE_NAME_FULL");
+			type = "ramdisk";
+			arch = "TARGET_ARCH";
+			os = "linux";
+			compression = "none";
+
+			hash@1 {
+				algo = "sha1";
+			};
+		};
+	};
+
+	configurations {
+		default = "conf@MACHINE";
+		conf@MACHINE {
+			description = "1 Linux kernel, FDT blob, ramdisk";
+			kernel = "kernel@1";
+			fdt = "fdt@1";
+			ramdisk = "ramdisk@1";
+
+			hash@1 {
+				algo = "sha1";
+			};
+		};
+	};
+};

--- a/recipes-core/images/fsl-image-mfgtool-initramfs.bbappend
+++ b/recipes-core/images/fsl-image-mfgtool-initramfs.bbappend
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2022 iris-GmbH infrared & intelligent sensors
+
+CORE_IMAGE_BASE_INSTALL_append = " \
+    lvm2 \
+    cryptsetup \
+"

--- a/recipes-core/images/irma6-fit.inc
+++ b/recipes-core/images/irma6-fit.inc
@@ -51,3 +51,76 @@ do_assemble_fit_prepend() {
 	fi
 }
 
+# overwrite meta-secure-imx/recipes-core/images/image-fit.inc
+do_assemble_fit() {
+	echo "STAGING_KERNEL_DIR" ${STAGING_KERNEL_DIR}
+	echo "STAGING_KERNEL_BUILDDIR" ${STAGING_KERNEL_BUILDDIR}
+	echo "KERNEL_SRC_PATH" ${KERNEL_SRC_PATH}
+	export DEPLOY_DIR_IMAGE=${DEPLOY_DIR_IMAGE}
+	export KERNEL_DEVICETREE=${KERNEL_DEVICETREE}
+	export RESCUE_NAME_FULL=${RESCUE_NAME_FULL}
+	export RESCUE_RUNNING_VERSION=${RESCUE_RUNNING_VERSION}
+	export MACHINE=${MACHINE}
+	export TARGET_ARCH=${TARGET_ARCH}
+	echo "B" ${B}
+	echo "S" ${S}
+	echo $DEPLOY_DIR_IMAGE
+	echo "FNAME " ${ITB_FNAME}
+	cd ${B}
+	cp ${B}/rescue.its.in ${B}/rescue.its
+	sed -i "s|DEPLOY_DIR_IMAGE|$DEPLOY_DIR_IMAGE|g" rescue.its
+	sed -i "s|RESCUE_NAME_FULL|$RESCUE_NAME_FULL|g" rescue.its
+	sed -i "s|RESCUE_RUNNING_VERSION|$RESCUE_RUNNING_VERSION|g" rescue.its
+	sed -i "s|MACHINE|$MACHINE|g" rescue.its
+	sed -i "s|TARGET_ARCH|$TARGET_ARCH|g" rescue.its
+	sed -i "s|KERNEL_DEVICETREE|$KERNEL_DEVICETREE|g" rescue.its
+	cat rescue.its
+	echo "======== create itb file ==========="
+	uboot-mkimage -D "-I dts -O dtb -p 0x1000" -f rescue.its ${ITB_FNAME}
+		if [ $? -ne 0 ]; then
+		echo create FIT image failed
+		exit 1
+	fi
+
+	install -d ${DEPLOY_DIR_IMAGE}
+	install -m 644 ${ITB_FNAME} ${DEPLOY_DIR_IMAGE}/${ITB_FNAME}
+
+	prepare_hab_image ${ITB_FNAME}
+	install ${ITB_FNAME}-ivt.${KERNEL_SIGN_SUFFIX} ${DEPLOY_DIR_IMAGE}/${ITB_FNAME}.${KERNEL_SIGN_SUFFIX}
+}
+
+# overwrite meta-secure-imx/classes/fitimage-hab-sign.bbclass
+csf_emit_file() {
+	cat << EOF > ${1}
+[Header]
+Version = 4.1
+Hash Algorithm = sha256
+Engine Configuration = 0
+Certificate Format = X509
+Signature Format = CMS
+Engine = ${7}
+
+[Install SRK]
+File = "${2}"
+Source index = 0
+
+[Install CSFK]
+File = "${3}"
+
+[Authenticate CSF]
+
+[Install Key]
+Verification index = 0
+Target Index = 2
+File= "${4}"
+
+[Authenticate Data]
+Verification index = 2
+Blocks = ${5} "${6}"
+
+[Unlock]
+Engine = ${7}
+Features = RNG
+EOF
+}
+

--- a/recipes-core/images/irma6-fit.inc
+++ b/recipes-core/images/irma6-fit.inc
@@ -59,9 +59,22 @@ do_assemble_fit() {
 	export DEPLOY_DIR_IMAGE=${DEPLOY_DIR_IMAGE}
 	export KERNEL_DEVICETREE=${KERNEL_DEVICETREE}
 	export RESCUE_NAME_FULL=${RESCUE_NAME_FULL}
-	export RESCUE_RUNNING_VERSION=${RESCUE_RUNNING_VERSION}
+	export FITIMAGE_DESCRIPTION="${FITIMAGE_DESCRIPTION}"
+	export FITIMAGE_RUNNING_VERSION=${FITIMAGE_RUNNING_VERSION}
 	export MACHINE=${MACHINE}
-	export TARGET_ARCH=${TARGET_ARCH}
+	export ITS_KERNEL_LOAD_ADDR=${ITS_KERNEL_LOAD_ADDR}
+	export ITS_KERNEL_ENTRY_ADDR=${ITS_KERNEL_ENTRY_ADDR}
+	export KERNEL_IMAGETYPE=${KERNEL_IMAGETYPE}
+	if [ "${KERNEL_IMAGETYPE}" = "Image.gz" ]; then
+		export KERNEL_COMPRESSION=gzip
+	else
+		export KERNEL_COMPRESSION=none
+	fi
+	if [ "${TARGET_ARCH}" = "aarch64" ]; then
+		export TARGET_ARCH=arm64
+	else
+		export TARGET_ARCH=${TARGET_ARCH}
+	fi
 	echo "B" ${B}
 	echo "S" ${S}
 	echo $DEPLOY_DIR_IMAGE
@@ -70,10 +83,15 @@ do_assemble_fit() {
 	cp ${B}/rescue.its.in ${B}/rescue.its
 	sed -i "s|DEPLOY_DIR_IMAGE|$DEPLOY_DIR_IMAGE|g" rescue.its
 	sed -i "s|RESCUE_NAME_FULL|$RESCUE_NAME_FULL|g" rescue.its
-	sed -i "s|RESCUE_RUNNING_VERSION|$RESCUE_RUNNING_VERSION|g" rescue.its
+	sed -i "s|FITIMAGE_DESCRIPTION|$FITIMAGE_DESCRIPTION|g" rescue.its
+	sed -i "s|FITIMAGE_RUNNING_VERSION|$FITIMAGE_RUNNING_VERSION|g" rescue.its
 	sed -i "s|MACHINE|$MACHINE|g" rescue.its
 	sed -i "s|TARGET_ARCH|$TARGET_ARCH|g" rescue.its
-	sed -i "s|KERNEL_DEVICETREE|$KERNEL_DEVICETREE|g" rescue.its
+	sed -i "s|KERNEL_IMAGETYPE|$KERNEL_IMAGETYPE|g" rescue.its
+	sed -i "s|KERNEL_COMPRESSION|$KERNEL_COMPRESSION|g" rescue.its
+	sed -i "s|KERNEL_DEVICETREE|$(basename $KERNEL_DEVICETREE)|g" rescue.its
+	sed -i "s|ITS_KERNEL_LOAD_ADDR|$ITS_KERNEL_LOAD_ADDR|g" rescue.its
+	sed -i "s|ITS_KERNEL_ENTRY_ADDR|$ITS_KERNEL_ENTRY_ADDR|g" rescue.its
 	cat rescue.its
 	echo "======== create itb file ==========="
 	uboot-mkimage -D "-I dts -O dtb -p 0x1000" -f rescue.its ${ITB_FNAME}
@@ -93,7 +111,7 @@ do_assemble_fit() {
 csf_emit_file() {
 	cat << EOF > ${1}
 [Header]
-Version = 4.1
+Version = 4.5
 Hash Algorithm = sha256
 Engine Configuration = 0
 Certificate Format = X509

--- a/recipes-core/images/irma6-fit.inc
+++ b/recipes-core/images/irma6-fit.inc
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2022 iris-GmbH infrared & intelligent sensors
+
+# require inc-file from meta-secure-imx
+require recipes-core/images/image-fit.inc
+
+COMPATIBLE_MACHINE = "mx8"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+KERNEL_SIGN_SUFFIX = "signed"
+RESCUE_NAME_FULL ?= "${RESCUE_NAME}-${MACHINE}.cpio.gz"
+
+# Overwrite KERNEL_DEVICETREE as it is a multiline variable defined in meta-freescale/conf/machine
+KERNEL_DEVICETREE_imx8mpevk = "freescale/imx8mp-evk.dtb"
+
+# Define load addresses for imx8mp hardware
+ITS_KERNEL_LOAD_ADDR_mx8mp = "0x40480000"
+ITS_KERNEL_ENTRY_ADDR_mx8mp = "0x40480000"
+FITLOADADDR_mx8mp = "0x48000000"
+
+# include checking of HAB/CST related variables
+inherit irma6-signing-variable-check
+addtask do_signing_variable_check before do_assemble_fit
+
+do_assemble_fit_prepend() {
+	if [ -z "${FITLOADADDR}" ]; then
+		FITLOADADDR=0x48000000
+		bbwarn "Set FITLOADADDR to ${FITLOADADDR}"
+	fi
+
+	if [ -z "${RESCUE_NAME_FULL}" ]; then
+		bbwarn "RESCUE_NAME_FULL is not set"
+	fi
+
+	if [ -z "${FITIMAGE_DESCRIPTION}" ]; then
+		bbwarn "FITIMAGE_DESCRIPTION is not set"
+	fi
+
+	if [ -z "${FITIMAGE_RUNNING_VERSION}" ]; then
+		FITIMAGE_RUNNING_VERSION=0.0.0
+		bbwarn "Set FITIMAGE_RUNNING_VERSION to ${FITIMAGE_RUNNING_VERSION}"
+	fi
+
+	if [ -z "${ITS_KERNEL_LOAD_ADDR}" ]; then
+		bbwarn "ITS_KERNEL_LOAD_ADDR is not set"
+	fi
+
+	if [ -z "${ITS_KERNEL_ENTRY_ADDR}" ]; then
+		bbwarn "ITS_KERNEL_ENTRY_ADDR is not set"
+	fi
+}
+

--- a/recipes-core/images/irma6-fitimage-uuu.bb
+++ b/recipes-core/images/irma6-fitimage-uuu.bb
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2022 iris-GmbH infrared & intelligent sensors
+
+SUMMARY = "IRMA6 FIT image with initramfs to be used with uuu/mfgtools"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+FITIMAGE_DESCRIPTION = "IRMA6 uuu initial operation fitimage"
+FITIMAGE_RUNNING_VERSION = "1.0"
+
+# name of the recipe, which creates the rescue rootfs
+RESCUE_NAME = "fsl-image-mfgtool-initramfs"
+RESCUE_NAME_FULL = "${RESCUE_NAME}-${MACHINE}.cpio.gz.u-boot"
+
+require irma6-fit.inc

--- a/recipes-core/images/irma6-fitimage.bb
+++ b/recipes-core/images/irma6-fitimage.bb
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2022 iris-GmbH infrared & intelligent sensors
+
+SUMMARY = "IRMA6 FIT image with initramfs"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+FITIMAGE_DESCRIPTION = "IRMA6 default fitimage"
+FITIMAGE_RUNNING_VERSION = "1.0"
+
+# name of the recipe, which creates the initramfs
+RESCUE_NAME = "crypt-image-initramfs"
+
+require irma6-fit.inc


### PR DESCRIPTION
This pull request adds all necessary configuration files and recipes to build signed fitimages.

Fitimages can be build with the two new recipes:
- `irma6-fitimage`: initial image containing the initramfs that gets flashed
- `irma6-fitimage-uuu`: fitimage that is use during initial operation via uuu

Building any of these two recipes should lead to a file named `[recipe name].itb.signed` in the deploy directory.

**Note:** The fitimage-uuu can not boot for now, the included initramfs is broken and will be fixed in a later PR.