### PR TITLE
feature/iada/rdphoen 1079 enable kernel bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [APR's Version Numbering](https://apr.apache.org/ver
 - [RDPHOEN-1083]: Sign bootable image: imx-boot.signed
 - [RDPHOEN-1142]: Add signing and fitimage configuration and recipes for irma6 fitimages
 - [RDPHOEN-1129]: LVM setup with R2 uuu images, switch to booting signed fitimages with initramfs
+- [RDPHOEN-1143]: Add dm-verity for rootfs volumes (in uuu and initramfs)
 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [APR's Version Numbering](https://apr.apache.org/ver
 - [RDPHOEN-1142]: Add signing and fitimage configuration and recipes for irma6 fitimages
 - [RDPHOEN-1129]: LVM setup with R2 uuu images, switch to booting signed fitimages with initramfs
 - [RDPHOEN-1143]: Add dm-verity for rootfs volumes (in uuu and initramfs)
+- [RDPHOEN-1079]: Bump BL31 to v2.4, enables booting newer kernels
 
 
 ### Changed

--- a/conf/multiconfig/imx8mp-evk.conf
+++ b/conf/multiconfig/imx8mp-evk.conf
@@ -9,3 +9,6 @@ UPDATE_PROCEDURE = "swupdate"
 IRMA6_RELEASE = "2"
 # whitelist mongoose for this config, as the evaluation kit is only used during prototyping: https://www.cesanta.com/license/
 LICENSE_FLAGS_WHITELIST += "commercial_mongoose"
+
+# Using dm-verity to wrap the rootfs only works with a blocksize of 4096 as dm-verity supports no other blocksize. Overwrite default blocksize:
+EXTRA_IMAGECMD_ext4 = "-b 4096"

--- a/conf/multiconfig/imx8mp-irma6r2.conf
+++ b/conf/multiconfig/imx8mp-irma6r2.conf
@@ -9,3 +9,6 @@ UPDATE_PROCEDURE = "swupdate"
 IRMA6_RELEASE = "2"
 # whitelist mongoose for imx8mp-irma6r2, as it is covered by a commercial product license: http://wiki.iris-sensing.net/display/ESAS/Software-Lizenzen
 LICENSE_FLAGS_WHITELIST += "commercial_mongoose"
+
+# Using dm-verity to wrap the rootfs only works with a blocksize of 4096 as dm-verity supports no other blocksize. Overwrite default blocksize:
+EXTRA_IMAGECMD_ext4 = "-b 4096"

--- a/recipes-bsp/imx-atf/imx-atf_%.bbappend
+++ b/recipes-bsp/imx-atf/imx-atf_%.bbappend
@@ -1,0 +1,4 @@
+# Bump BL31 version to 2.4
+SRCBRANCH = "lf_v2.4"
+SRC_URI = "git://source.codeaurora.org/external/imx/imx-atf.git;protocol=https;branch=${SRCBRANCH}"
+SRCREV = "ec35fef92b71a79075f214f8cff0738cd4482ed0"

--- a/recipes-bsp/imx-mkimage/files/0002-MLK-24913-iMX8MP-Update-the-atf-load-address-to-0x97.patch
+++ b/recipes-bsp/imx-mkimage/files/0002-MLK-24913-iMX8MP-Update-the-atf-load-address-to-0x97.patch
@@ -1,0 +1,30 @@
+From b51cb3ccb382a3b4a93c8aab9d7f010af8ae3b22 Mon Sep 17 00:00:00 2001
+From: Jacky Bai <ping.bai@nxp.com>
+Date: Thu, 22 Oct 2020 17:46:44 +0800
+Subject: [PATCH] MLK-24913 iMX8MP: Update the atf load address to 0x970000
+
+Update the ATF load address to 0x970000 to provide a
+continuous OCRAM space for other purpose.
+
+Signed-off-by: Jacky Bai <ping.bai@nxp.com>
+Reviewed-by: Ye Li <ye.li@nxp.com>
+---
+ iMX8M/soc.mak | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/iMX8M/soc.mak b/iMX8M/soc.mak
+index b7b3986..161b035 100644
+--- a/iMX8M/soc.mak
++++ b/iMX8M/soc.mak
+@@ -55,7 +55,7 @@ HDMI = no
+ SPL_LOAD_ADDR = 0x920000
+ SPL_FSPI_LOAD_ADDR = 0x920000
+ TEE_LOAD_ADDR =  0x56000000
+-ATF_LOAD_ADDR = 0x00960000
++ATF_LOAD_ADDR = 0x00970000
+ VAL_BOARD = val
+ #define the F(Q)SPI header file
+ QSPI_HEADER = ../scripts/fspi_header
+-- 
+2.25.1
+

--- a/recipes-bsp/imx-mkimage/imx-boot_%.bbappend
+++ b/recipes-bsp/imx-mkimage/imx-boot_%.bbappend
@@ -7,6 +7,7 @@ SRC_URI_append_imx8mp-irma6r2 = " \
 "
 SRC_URI_append = " \
     file://0001-Fix-cleanup-Remove-device-tree-deletion-after-make.patch \
+    file://0002-MLK-24913-iMX8MP-Update-the-atf-load-address-to-0x97.patch \
 "
 
 SOC_TARGET_imx8mp-irma6r2 = "iMX8MPI6R2"

--- a/recipes-bsp/irma6-uuu/files/flashall_imx8mp.uuu
+++ b/recipes-bsp/irma6-uuu/files/flashall_imx8mp.uuu
@@ -76,6 +76,19 @@ FBK: acmd zcat | dd of=/dev/mapper/irma6lvm-rootfs_b
 FBK: ucp rootfs.ext4.gz t:-
 FBK: ucmd sync
 
+# Create fat data partition (keystore)
+FBK: ucmd mkfs.vfat /dev/mapper/irma6lvm-keystore
+FBK: ucmd mkdir -p /mnt/keystore
+FBK: ucmd mount -t vfat /dev/mapper/irma6lvm-keystore /mnt/keystore
+
+# !! The root hashes for the dm-verity volumes are generated here !!
+# TODO: Unsafe! Store roothash in a secure manner!
+FBK: ucmd veritysetup format /dev/mapper/irma6lvm-rootfs_a /dev/mapper/irma6lvm-rootfs_a_hash | grep "Root hash:" | grep -Eo "[0-9a-f]+$" > /mnt/keystore/rootfs_a_roothash
+FBK: ucmd veritysetup format /dev/mapper/irma6lvm-rootfs_b /dev/mapper/irma6lvm-rootfs_b_hash | grep "Root hash:" | grep -Eo "[0-9a-f]+$" > /mnt/keystore/rootfs_b_roothash
+
+FBK: ucmd umount /mnt/keystore
+FBK: ucmd sync
+
 # Hashsum check
 FBK: ucp verification.sh t:/tmp
 FBK: ucp hashsums t:/tmp

--- a/recipes-bsp/irma6-uuu/files/verification_imx8mp.sh
+++ b/recipes-bsp/irma6-uuu/files/verification_imx8mp.sh
@@ -24,8 +24,13 @@ sha256sum /mnt/fat/fitImage.signed | cut -d' ' -f1 | grep $HASH_FITIMAGE || { ec
 umount /mnt/fat
 sync
 
+mkdir -p /mnt/keystore
+mount -t vfat /dev/mapper/irma6lvm-keystore /mnt/keystore
 echo "Verify hash of rootfs on /dev/mapper/irma6lvm-rootfs_a"
 head -c "$SIZE_ROOTFS" /dev/mapper/irma6lvm-rootfs_a | sha256sum - | cut -d' ' -f1 | grep $HASH_ROOTFS || { echo "Error: Failed to verify hash of rootfs on /dev/mapper/irma6lvm-rootfs_a"; exit 1; }
+veritysetup verify /dev/mapper/irma6lvm-rootfs_a /dev/mapper/irma6lvm-rootfs_a_hash $(cat /mnt/keystore/rootfs_a_roothash) || { echo "Error: dm-verity verification fail on /dev/mapper/irma6lvm-rootfs_a"; exit 1; }
 echo "Verify hash of rootfs on /dev/mapper/irma6lvm-rootfs_b"
 head -c "$SIZE_ROOTFS" /dev/mapper/irma6lvm-rootfs_b | sha256sum - | cut -d' ' -f1 | grep $HASH_ROOTFS || { echo "Error: Failed to verify hash of rootfs on /dev/mapper/irma6lvm-rootfs_b"; exit 1; }
+veritysetup verify /dev/mapper/irma6lvm-rootfs_b /dev/mapper/irma6lvm-rootfs_b_hash $(cat /mnt/keystore/rootfs_b_roothash) || { echo "Error: dm-verity verification fail on /dev/mapper/irma6lvm-rootfs_b"; exit 1; }
+umount /mnt/keystore
 


### PR DESCRIPTION
The CAAM driver is only available on a slightly newer kernel, and there is an unclear dependency with the BL31 firmware.
This updates the BL31 to v2.4, which enables the correct booting of newer kernels. 