### PR TITLE
Feature/migl/rdphoen 1153 env writeable list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [APR's Version Numbering](https://apr.apache.org/ver
 - linux-fslc-iris: Remove kernel from the rootfs & initramfs, because it remains unused for the fitImage setup
 - [RDPHOEN-1140]: Add redundand u-boot-env support and missing release 2 packages: lvm2, cryptsetup libubootenv-bin
 - [RDPHOEN-1178]: Add CAAM rng prediction resistance in Uboot, enables the correct hw rng initialization in Linux.
+- [RDPHOEN-1153]: Add u-boot env writeable list feature
 - [RDPHOEN-1180]: Use different fstab for R2 to mount the userdata volume
 - [RDPHOEN-1140]: Make swu images work with new partitioning/volumes
 - [RDPHOEN-1144]: Bump Kernel to 5.4-2.3.x-imx and enable CAAM API

--- a/recipes-bsp/u-boot/u-boot-imx/common/0005-env-Warn-on-force-access-if-ENV_ACCESS_IGNORE_FORCE-.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/common/0005-env-Warn-on-force-access-if-ENV_ACCESS_IGNORE_FORCE-.patch
@@ -1,0 +1,33 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Marek Vasut <marex@denx.de>
+Date: Tue, 7 Jul 2020 20:51:33 +0200
+Subject: [PATCH] env: Warn on force access if ENV_ACCESS_IGNORE_FORCE set
+
+If the ENV_ACCESS_IGNORE_FORCE is set, inform user that the variable
+cannot be force-set if such attempt happens.
+
+Signed-off-by: Marek Vasut <marex@denx.de>
+Reviewed-by: Tom Rini <trini@konsulko.com>
+---
+ env/flags.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/env/flags.c b/env/flags.c
+index 418d6cc742..5a5910c480 100644
+--- a/env/flags.c
++++ b/env/flags.c
+@@ -525,8 +525,10 @@ int env_flags_validate(const struct env_entry *item, const char *newval,
+ 
+ 	/* check for access permission */
+ #ifndef CONFIG_ENV_ACCESS_IGNORE_FORCE
+-	if (flag & H_FORCE)
++	if (flag & H_FORCE) {
++		printf("## Error: Can't force access to \"%s\"\n", name);
+ 		return 0;
++	}
+ #endif
+ 	switch (op) {
+ 	case env_op_delete:
+-- 
+2.36.1
+

--- a/recipes-bsp/u-boot/u-boot-imx/common/0006-env-Add-H_DEFAULT-flag.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/common/0006-env-Add-H_DEFAULT-flag.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Marek Vasut <marex@denx.de>
+Date: Tue, 7 Jul 2020 20:51:34 +0200
+Subject: [PATCH] env: Add H_DEFAULT flag
+
+Add another internal environment flag which indicates that the operation
+is resetting the environment to the default one. This allows the env code
+to discern between import of external environment and reset to default.
+
+Signed-off-by: Marek Vasut <marex@denx.de>
+Reviewed-by: Tom Rini <trini@konsulko.com>
+---
+ env/common.c     | 3 ++-
+ include/search.h | 1 +
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/env/common.c b/env/common.c
+index 1fd1bd01d3..225883206b 100644
+--- a/env/common.c
++++ b/env/common.c
+@@ -79,6 +79,7 @@ void env_set_default(const char *s, int flags)
+ 		debug("Using default environment\n");
+ 	}
+ 
++	flags |= H_DEFAULT;
+ 	if (himport_r(&env_htab, (char *)default_environment,
+ 			sizeof(default_environment), '\0', flags, 0,
+ 			0, NULL) == 0)
+@@ -97,7 +98,7 @@ int env_set_default_vars(int nvars, char * const vars[], int flags)
+ 	 * Special use-case: import from default environment
+ 	 * (and use \0 as a separator)
+ 	 */
+-	flags |= H_NOCLEAR;
++	flags |= H_NOCLEAR | H_DEFAULT;
+ 	return himport_r(&env_htab, (const char *)default_environment,
+ 				sizeof(default_environment), '\0',
+ 				flags, 0, nvars, vars);
+diff --git a/include/search.h b/include/search.h
+index 0469a852e0..810698713b 100644
+--- a/include/search.h
++++ b/include/search.h
+@@ -110,5 +110,6 @@ int hwalk_r(struct hsearch_data *htab,
+ #define H_MATCH_METHOD	(H_MATCH_IDENT | H_MATCH_SUBSTR | H_MATCH_REGEX)
+ #define H_PROGRAMMATIC	(1 << 9) /* indicate that an import is from env_set() */
+ #define H_ORIGIN_FLAGS	(H_INTERACTIVE | H_PROGRAMMATIC)
++#define H_DEFAULT	(1 << 10) /* indicate that an import is default env */
+ 
+ #endif /* _SEARCH_H_ */
+-- 
+2.36.1
+

--- a/recipes-bsp/u-boot/u-boot-imx/common/0007-env-Discern-environment-coming-from-external-storage.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/common/0007-env-Discern-environment-coming-from-external-storage.patch
@@ -1,0 +1,435 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Marek Vasut <marex@denx.de>
+Date: Tue, 7 Jul 2020 20:51:35 +0200
+Subject: [PATCH] env: Discern environment coming from external storage
+
+Add another custom environment flag which discerns environment coming
+from external storage from environment set by U-Boot itself.
+
+Signed-off-by: Marek Vasut <marex@denx.de>
+Reviewed-by: Tom Rini <trini@konsulko.com>
+---
+ env/common.c     | 13 +++++-----
+ env/eeprom.c     |  2 +-
+ env/ext4.c       | 63 ++++++++++++++++++++++++++++++++++++++----------
+ env/fat.c        |  2 +-
+ env/flash.c      |  2 +-
+ env/mmc.c        |  4 +--
+ env/nand.c       |  4 +--
+ env/nvram.c      |  2 +-
+ env/onenand.c    |  2 +-
+ env/remote.c     |  2 +-
+ env/sata.c       |  2 +-
+ env/sf.c         |  4 +--
+ env/ubi.c        |  4 +--
+ include/env.h    |  7 ++++--
+ include/search.h |  1 +
+ 15 files changed, 78 insertions(+), 36 deletions(-)
+
+diff --git a/env/common.c b/env/common.c
+index 225883206b..d70274d903 100644
+--- a/env/common.c
++++ b/env/common.c
+@@ -108,7 +108,7 @@ int env_set_default_vars(int nvars, char * const vars[], int flags)
+  * Check if CRC is valid and (if yes) import the environment.
+  * Note that "buf" may or may not be aligned.
+  */
+-int env_import(const char *buf, int check)
++int env_import(const char *buf, int check, int flags)
+ {
+ 	env_t *ep = (env_t *)buf;
+ 
+@@ -123,7 +123,7 @@ int env_import(const char *buf, int check)
+ 		}
+ 	}
+ 
+-	if (himport_r(&env_htab, (char *)ep->data, ENV_SIZE, '\0', 0, 0,
++	if (himport_r(&env_htab, (char *)ep->data, ENV_SIZE, '\0', flags, 0,
+ 			0, NULL)) {
+ 		gd->flags |= GD_FLG_ENV_READY;
+ 		return 0;
+@@ -140,7 +140,8 @@ int env_import(const char *buf, int check)
+ static unsigned char env_flags;
+ 
+ int env_import_redund(const char *buf1, int buf1_read_fail,
+-		      const char *buf2, int buf2_read_fail)
++		      const char *buf2, int buf2_read_fail,
++		      int flags)
+ {
+ 	int crc1_ok, crc2_ok;
+ 	env_t *ep, *tmp_env1, *tmp_env2;
+@@ -160,10 +161,10 @@ int env_import_redund(const char *buf1, int buf1_read_fail,
+ 		return -EIO;
+ 	} else if (!buf1_read_fail && buf2_read_fail) {
+ 		gd->env_valid = ENV_VALID;
+-		return env_import((char *)tmp_env1, 1);
++		return env_import((char *)tmp_env1, 1, flags);
+ 	} else if (buf1_read_fail && !buf2_read_fail) {
+ 		gd->env_valid = ENV_REDUND;
+-		return env_import((char *)tmp_env2, 1);
++		return env_import((char *)tmp_env2, 1, flags);
+ 	}
+ 
+ 	crc1_ok = crc32(0, tmp_env1->data, ENV_SIZE) ==
+@@ -198,7 +199,7 @@ int env_import_redund(const char *buf1, int buf1_read_fail,
+ 		ep = tmp_env2;
+ 
+ 	env_flags = ep->flags;
+-	return env_import((char *)ep, 0);
++	return env_import((char *)ep, 0, flags);
+ }
+ #endif /* CONFIG_SYS_REDUNDAND_ENVIRONMENT */
+ 
+diff --git a/env/eeprom.c b/env/eeprom.c
+index b12bdec652..87f82a9ed9 100644
+--- a/env/eeprom.c
++++ b/env/eeprom.c
+@@ -188,7 +188,7 @@ static int env_eeprom_load(void)
+ 	eeprom_bus_read(CONFIG_SYS_DEF_EEPROM_ADDR,
+ 		off, (uchar *)buf_env, CONFIG_ENV_SIZE);
+ 
+-	return env_import(buf_env, 1);
++	return env_import(buf_env, 1, H_EXTERNAL);
+ }
+ 
+ static int env_eeprom_save(void)
+diff --git a/env/ext4.c b/env/ext4.c
+index 1f6b1b5bd8..f823b69409 100644
+--- a/env/ext4.c
++++ b/env/ext4.c
+@@ -19,6 +19,7 @@
+  */
+ 
+ #include <common.h>
++#include <part.h>
+ 
+ #include <command.h>
+ #include <env.h>
+@@ -31,6 +32,8 @@
+ #include <ext4fs.h>
+ #include <mmc.h>
+ 
++DECLARE_GLOBAL_DATA_PTR;
++
+ __weak const char *env_ext4_get_intf(void)
+ {
+ 	return (const char *)CONFIG_ENV_EXT4_INTERFACE;
+@@ -41,21 +44,15 @@ __weak const char *env_ext4_get_dev_part(void)
+ 	return (const char *)CONFIG_ENV_EXT4_DEVICE_AND_PART;
+ }
+ 
+-#ifdef CONFIG_CMD_SAVEENV
+-static int env_ext4_save(void)
++static int env_ext4_save_buffer(env_t *env_new)
+ {
+-	env_t	env_new;
+ 	struct blk_desc *dev_desc = NULL;
+-	disk_partition_t info;
++	struct disk_partition info;
+ 	int dev, part;
+ 	int err;
+ 	const char *ifname = env_ext4_get_intf();
+ 	const char *dev_and_part = env_ext4_get_dev_part();
+ 
+-	err = env_export(&env_new);
+-	if (err)
+-		return err;
+-
+ 	part = blk_get_device_part_str(ifname, dev_and_part,
+ 				       &dev_desc, &info, 1);
+ 	if (part < 0)
+@@ -70,7 +67,7 @@ static int env_ext4_save(void)
+ 		return 1;
+ 	}
+ 
+-	err = ext4fs_write(CONFIG_ENV_EXT4_FILE, (void *)&env_new,
++	err = ext4fs_write(CONFIG_ENV_EXT4_FILE, (void *)env_new,
+ 			   sizeof(env_t), FILETYPE_REG);
+ 	ext4fs_close();
+ 
+@@ -80,16 +77,50 @@ static int env_ext4_save(void)
+ 		return 1;
+ 	}
+ 
++	return 0;
++}
++
++static int env_ext4_save(void)
++{
++	env_t env_new;
++	int err;
++
++	err = env_export(&env_new);
++	if (err)
++		return err;
++
++	err = env_ext4_save_buffer(&env_new);
++	if (err)
++		return err;
++
++	gd->env_valid = ENV_VALID;
+ 	puts("done\n");
++
++	return 0;
++}
++
++static int env_ext4_erase(void)
++{
++	env_t env_new;
++	int err;
++
++	memset(&env_new, 0, sizeof(env_t));
++
++	err = env_ext4_save_buffer(&env_new);
++	if (err)
++		return err;
++
++	gd->env_valid = ENV_INVALID;
++	puts("done\n");
++
+ 	return 0;
+ }
+-#endif /* CONFIG_CMD_SAVEENV */
+ 
+ static int env_ext4_load(void)
+ {
+ 	ALLOC_CACHE_ALIGN_BUFFER(char, buf, CONFIG_ENV_SIZE);
+ 	struct blk_desc *dev_desc = NULL;
+-	disk_partition_t info;
++	struct disk_partition info;
+ 	int dev, part;
+ 	int err;
+ 	loff_t off;
+@@ -125,7 +156,11 @@ static int env_ext4_load(void)
+ 		goto err_env_relocate;
+ 	}
+ 
+-	return env_import(buf, 1);
++	err = env_import(buf, 1, H_EXTERNAL);
++	if (!err)
++		gd->env_valid = ENV_VALID;
++
++	return err;
+ 
+ err_env_relocate:
+ 	env_set_default(NULL, 0);
+@@ -137,5 +172,7 @@ U_BOOT_ENV_LOCATION(ext4) = {
+ 	.location	= ENVL_EXT4,
+ 	ENV_NAME("EXT4")
+ 	.load		= env_ext4_load,
+-	.save		= env_save_ptr(env_ext4_save),
++	.save		= ENV_SAVE_PTR(env_ext4_save),
++	.erase		= CONFIG_IS_ENABLED(CMD_ERASEENV) ? env_ext4_erase :
++							    NULL,
+ };
+diff --git a/env/fat.c b/env/fat.c
+index 1836556f36..9f1b108fb7 100644
+--- a/env/fat.c
++++ b/env/fat.c
+@@ -120,7 +120,7 @@ static int env_fat_load(void)
+ 		goto err_env_relocate;
+ 	}
+ 
+-	return env_import(buf, 1);
++	return env_import(buf, 1, H_EXTERNAL);
+ 
+ err_env_relocate:
+ 	env_set_default(NULL, 0);
+diff --git a/env/flash.c b/env/flash.c
+index e05f7ef74b..4e52f24f5e 100644
+--- a/env/flash.c
++++ b/env/flash.c
+@@ -350,7 +350,7 @@ static int env_flash_load(void)
+ 		     "reading environment; recovered successfully\n\n");
+ #endif /* CONFIG_ENV_ADDR_REDUND */
+ 
+-	return env_import((char *)flash_addr, 1);
++	return env_import((char *)flash_addr, 1, H_EXTERNAL);
+ }
+ #endif /* LOADENV */
+ 
+diff --git a/env/mmc.c b/env/mmc.c
+index 5f73e7abfb..7833404cd1 100644
+--- a/env/mmc.c
++++ b/env/mmc.c
+@@ -332,7 +332,7 @@ static int env_mmc_load(void)
+ 	read2_fail = read_env(mmc, CONFIG_ENV_SIZE, offset2, tmp_env2);
+ 
+ 	ret = env_import_redund((char *)tmp_env1, read1_fail, (char *)tmp_env2,
+-				read2_fail);
++				read2_fail, H_EXTERNAL);
+ 
+ fini:
+ 	fini_mmc_for_env(mmc);
+@@ -374,7 +374,7 @@ static int env_mmc_load(void)
+ 		goto fini;
+ 	}
+ 
+-	ret = env_import(buf, 1);
++	ret = env_import(buf, 1, H_EXTERNAL);
+ 	if (!ret) {
+ 		ep = (env_t *)buf;
+ 		gd->env_addr = (ulong)&ep->data;
+diff --git a/env/nand.c b/env/nand.c
+index 5ff5fa1e5d..2460dffbf2 100644
+--- a/env/nand.c
++++ b/env/nand.c
+@@ -323,7 +323,7 @@ static int env_nand_load(void)
+ 	read2_fail = readenv(CONFIG_ENV_OFFSET_REDUND, (u_char *) tmp_env2);
+ 
+ 	ret = env_import_redund((char *)tmp_env1, read1_fail, (char *)tmp_env2,
+-				read2_fail);
++				read2_fail, H_EXTERNAL);
+ 
+ done:
+ 	free(tmp_env1);
+@@ -364,7 +364,7 @@ static int env_nand_load(void)
+ 		return -EIO;
+ 	}
+ 
+-	return env_import(buf, 1);
++	return env_import(buf, 1, H_EXTERNAL);
+ #endif /* ! ENV_IS_EMBEDDED */
+ 
+ 	return 0;
+diff --git a/env/nvram.c b/env/nvram.c
+index a78db21623..2837b158be 100644
+--- a/env/nvram.c
++++ b/env/nvram.c
+@@ -64,7 +64,7 @@ static int env_nvram_load(void)
+ #else
+ 	memcpy(buf, (void *)CONFIG_ENV_ADDR, CONFIG_ENV_SIZE);
+ #endif
+-	return env_import(buf, 1);
++	return env_import(buf, 1, H_EXTERNAL);
+ }
+ 
+ static int env_nvram_save(void)
+diff --git a/env/onenand.c b/env/onenand.c
+index dfd4e939f8..a2477cef9b 100644
+--- a/env/onenand.c
++++ b/env/onenand.c
+@@ -55,7 +55,7 @@ static int env_onenand_load(void)
+ 		mtd->writesize = MAX_ONENAND_PAGESIZE;
+ #endif /* !ENV_IS_EMBEDDED */
+ 
+-	rc = env_import(buf, 1);
++	rc = env_import(buf, 1, H_EXTERNAL);
+ 	if (!rc)
+ 		gd->env_valid = ENV_VALID;
+ 
+diff --git a/env/remote.c b/env/remote.c
+index 50d77b8dfe..cb00413b0f 100644
+--- a/env/remote.c
++++ b/env/remote.c
+@@ -45,7 +45,7 @@ static int env_remote_save(void)
+ static int env_remote_load(void)
+ {
+ #ifndef ENV_IS_EMBEDDED
+-	return env_import((char *)env_ptr, 1);
++	return env_import((char *)env_ptr, 1, H_EXTERNAL);
+ #endif
+ 
+ 	return 0;
+diff --git a/env/sata.c b/env/sata.c
+index 0349862f53..586395b301 100644
+--- a/env/sata.c
++++ b/env/sata.c
+@@ -129,7 +129,7 @@ static int env_sata_load(void)
+ 		return -EIO;
+ 	}
+ 
+-	return env_import(buf, 1);
++	return env_import(buf, 1, H_EXTERNAL);
+ }
+ 
+ U_BOOT_ENV_LOCATION(sata) = {
+diff --git a/env/sf.c b/env/sf.c
+index 7951c654d5..414bf30d06 100644
+--- a/env/sf.c
++++ b/env/sf.c
+@@ -176,7 +176,7 @@ static int env_sf_load(void)
+ 				    CONFIG_ENV_SIZE, tmp_env2);
+ 
+ 	ret = env_import_redund((char *)tmp_env1, read1_fail, (char *)tmp_env2,
+-				read2_fail);
++				read2_fail, H_EXTERNAL);
+ 
+ 	spi_flash_free(env_flash);
+ 	env_flash = NULL;
+@@ -271,7 +271,7 @@ static int env_sf_load(void)
+ 		goto err_read;
+ 	}
+ 
+-	ret = env_import(buf, 1);
++	ret = env_import(buf, 1, H_EXTERNAL);
+ 	if (!ret)
+ 		gd->env_valid = ENV_VALID;
+ 
+diff --git a/env/ubi.c b/env/ubi.c
+index 08aac47df2..5502efe28b 100644
+--- a/env/ubi.c
++++ b/env/ubi.c
+@@ -141,7 +141,7 @@ static int env_ubi_load(void)
+ 		       CONFIG_ENV_UBI_PART, CONFIG_ENV_UBI_VOLUME_REDUND);
+ 
+ 	return env_import_redund((char *)tmp_env1, read1_fail, (char *)tmp_env2,
+-							 read2_fail);
++				 read2_fail, H_EXTERNAL);
+ }
+ #else /* ! CONFIG_SYS_REDUNDAND_ENVIRONMENT */
+ static int env_ubi_load(void)
+@@ -172,7 +172,7 @@ static int env_ubi_load(void)
+ 		return -EIO;
+ 	}
+ 
+-	return env_import(buf, 1);
++	return env_import(buf, 1, H_EXTERNAL);
+ }
+ #endif /* CONFIG_SYS_REDUNDAND_ENVIRONMENT */
+ 
+diff --git a/include/env.h b/include/env.h
+index 5da50f3dd6..0176a04879 100644
+--- a/include/env.h
++++ b/include/env.h
+@@ -288,10 +288,11 @@ int env_erase(void);
+  * @buf: Buffer containing the environment (struct environemnt_s *)
+  * @check: non-zero to check the CRC at the start of the environment, 0 to
+  *	ignore it
++ * @flags: Flags controlling matching (H_... - see search.h)
+  * @return 0 if imported successfully, -ENOMSG if the CRC was bad, -EIO if
+  *	something else went wrong
+  */
+-int env_import(const char *buf, int check);
++int env_import(const char *buf, int check, int flags);
+ 
+ /**
+  * env_export() - Export the environment to a buffer
+@@ -310,10 +311,12 @@ int env_export(struct environment_s *env_out);
+  * @buf1_read_fail: 0 if buf1 is valid, non-zero if invalid
+  * @buf2: Second environment (struct environemnt_s *)
+  * @buf2_read_fail: 0 if buf2 is valid, non-zero if invalid
++ * @flags: Flags controlling matching (H_... - see search.h)
+  * @return 0 if OK, -EIO if no environment is valid, -ENOMSG if the CRC was bad
+  */
+ int env_import_redund(const char *buf1, int buf1_read_fail,
+-		      const char *buf2, int buf2_read_fail);
++		      const char *buf2, int buf2_read_fail,
++		      int flags);
+ 
+ /**
+  * env_get_default() - Look up a variable from the default environment
+diff --git a/include/search.h b/include/search.h
+index 810698713b..489be35ee8 100644
+--- a/include/search.h
++++ b/include/search.h
+@@ -111,5 +111,6 @@ int hwalk_r(struct hsearch_data *htab,
+ #define H_PROGRAMMATIC	(1 << 9) /* indicate that an import is from env_set() */
+ #define H_ORIGIN_FLAGS	(H_INTERACTIVE | H_PROGRAMMATIC)
+ #define H_DEFAULT	(1 << 10) /* indicate that an import is default env */
++#define H_EXTERNAL	(1 << 11) /* indicate that an import is external env */
+ 
+ #endif /* _SEARCH_H_ */
+-- 
+2.36.1
+

--- a/recipes-bsp/u-boot/u-boot-imx/common/0008-env-Add-option-to-only-ever-append-environment.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/common/0008-env-Add-option-to-only-ever-append-environment.patch
@@ -1,0 +1,347 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Marek Vasut <marex@denx.de>
+Date: Tue, 7 Jul 2020 20:51:38 +0200
+Subject: [PATCH] env: Add option to only ever append environment
+
+Add configuration option which prevents the environment hash table to be
+ever cleared and reloaded with different content. This is useful in case
+the first environment loaded into the hash table contains e.g. sensitive
+content which must not be dropped or reloaded.
+
+Signed-off-by: Marek Vasut <marex@denx.de>
+Reviewed-by: Tom Rini <trini@konsulko.com>
+---
+ env/Kconfig     | 68 ++++++++++++++++++++++++----------
+ env/env.c       | 98 ++++++++++++++++++++++++++++++++++++++++++-------
+ lib/hashtable.c |  4 ++
+ 3 files changed, 136 insertions(+), 34 deletions(-)
+
+diff --git a/env/Kconfig b/env/Kconfig
+index 4b94a15ac4..1cae1edf6a 100644
+--- a/env/Kconfig
++++ b/env/Kconfig
+@@ -3,6 +3,15 @@ menu "Environment"
+ config ENV_SUPPORT
+ 	def_bool y
+ 
++config SAVEENV
++	def_bool y if CMD_SAVEENV
++
++config ENV_OVERWRITE
++	bool "Enable overwriting environment"
++	help
++	  Use this to permit overriding of certain environmental variables
++	  like Ethernet and Serial
++
+ config ENV_IS_NOWHERE
+ 	bool "Environment is not stored"
+ 	default y if !ENV_IS_IN_EEPROM && !ENV_IS_IN_EXT4 && \
+@@ -10,7 +19,7 @@ config ENV_IS_NOWHERE
+ 		     !ENV_IS_IN_MMC && !ENV_IS_IN_NAND && \
+ 		     !ENV_IS_IN_NVRAM && !ENV_IS_IN_ONENAND && \
+ 		     !ENV_IS_IN_REMOTE && !ENV_IS_IN_SPI_FLASH && \
+-		     !ENV_IS_IN_UBI && !ENV_IS_IN_SATA
++		     !ENV_IS_IN_UBI
+ 	help
+ 	  Define this if you don't want to or can't have an environment stored
+ 	  on a storage medium. In this case the environment will still exist
+@@ -281,20 +290,6 @@ config ENV_IS_IN_REMOTE
+ 	  local device can get the environment from remote memory
+ 	  space by SRIO or PCIE links.
+ 
+-config ENV_IS_IN_SATA
+-    bool "Environment is in SATA disk"
+-    depends on !CHAIN_OF_TRUST
+-    help
+-      Define this if you have a SATA disk device which you
+-      want to use for the environment.
+-
+-      - CONFIG_ENV_OFFSET:
+-      - CONFIG_ENV_SIZE:
+-
+-      These two #defines specify the offset and size of the
+-      environment area within the SATA disk. CONFIG_ENV_OFFSET must be
+-      aligned to an disk sector boundary.
+-
+ config ENV_IS_IN_SPI_FLASH
+ 	bool "Environment is in SPI flash"
+ 	depends on !CHAIN_OF_TRUST && SPI
+@@ -418,8 +413,7 @@ config SYS_REDUNDAND_ENVIRONMENT
+ config ENV_FAT_INTERFACE
+ 	string "Name of the block device for the environment"
+ 	depends on ENV_IS_IN_FAT
+-	default "mmc" if ARCH_SUNXI
+-	default "mmc" if TI_COMMON_CMD_OPTIONS || ARCH_ZYNQMP || ARCH_AT91
++	default "mmc"
+ 	help
+ 	  Define this to a string that is the name of the block device.
+ 
+@@ -446,6 +440,10 @@ config ENV_FAT_DEVICE_AND_PART
+ 	                   If none, first valid partition in device D. If no
+ 	                   partition table then means device D.
+ 
++	  If ENV_FAT_INTERFACE is set to "mmc" then device 'D' can be omitted,
++	  leaving the string starting with a colon, and the boot device will
++	  be used.
++
+ config ENV_FAT_FILE
+ 	string "Name of the FAT file to use for the environment"
+ 	depends on ENV_IS_IN_FAT
+@@ -481,7 +479,7 @@ config ENV_EXT4_DEVICE_AND_PART
+ config ENV_EXT4_FILE
+ 	string "Name of the EXT4 file to use for the environment"
+ 	depends on ENV_IS_IN_EXT4
+-	default "uboot.env"
++	default "/uboot.env"
+ 	help
+ 	  It's a string of the EXT4 file name. This file use to store the
+ 	  environment (explicit path to the file)
+@@ -504,7 +502,7 @@ config ENV_ADDR_REDUND
+ config ENV_OFFSET
+ 	hex "Environment offset"
+ 	depends on ENV_IS_IN_EEPROM || ENV_IS_IN_MMC || ENV_IS_IN_NAND || \
+-		    ENV_IS_IN_SPI_FLASH || ENV_IS_IN_SATA
++		    ENV_IS_IN_SPI_FLASH
+ 	default 0x3f8000 if ARCH_ROCKCHIP && ENV_IS_IN_MMC
+ 	default 0x140000 if ARCH_ROCKCHIP && ENV_IS_IN_SPI_FLASH
+ 	default 0x88000 if ARCH_SUNXI
+@@ -514,6 +512,7 @@ config ENV_OFFSET
+ 	default 0 if ARC
+ 	default 0x140000 if ARCH_AT91
+ 	default 0x260000 if ARCH_OMAP2PLUS
++	default 0x1080000 if MICROBLAZE && ENV_IS_IN_SPI_FLASH
+ 	help
+ 	  Offset from the start of the device (or partition)
+ 
+@@ -543,6 +542,7 @@ config ENV_SECT_SIZE
+ 	default 0x2000 if ARCH_ROCKCHIP
+ 	default 0x40000 if ARCH_ZYNQMP || ARCH_VERSAL
+ 	default 0x20000 if ARCH_ZYNQ || ARCH_OMAP2PLUS || ARCH_AT91
++	default 0x20000 if MICROBLAZE && ENV_IS_IN_SPI_FLASH
+ 	help
+ 	  Size of the sector containing the environment.
+ 
+@@ -572,7 +572,7 @@ config ENV_UBI_VID_OFFSET
+ 	  UBI VID offset for environment. If 0, no custom VID offset is used.
+ 
+ config SYS_RELOC_GD_ENV_ADDR
+-	bool "Relocate gd->en_addr"
++	bool "Relocate gd->env_addr"
+ 	help
+ 	  Relocate the early env_addr pointer so we know it is not inside
+ 	  the binary. Some systems need this and for the rest, it doesn't hurt.
+@@ -602,6 +602,34 @@ config ENV_VARS_UBOOT_RUNTIME_CONFIG
+ 	  run-time determined information about the hardware to the
+ 	  environment.  These will be named board_name, board_rev.
+ 
++config DELAY_ENVIRONMENT
++	bool "Delay environment loading"
++	depends on !OF_CONTROL
++	help
++	  Enable this to inhibit loading the environment during board
++	  initialization. This can address the security risk of untrusted data
++	  being used during boot. Normally the environment is loaded when the
++	  board is initialised so that it is available to U-Boot. This inhibits
++	  that so that the environment is not available until explicitly loaded
++	  later by U-Boot code. With CONFIG_OF_CONTROL this is instead
++	  controlled by the value of /config/load-environment.
++
++config ENV_APPEND
++	bool "Always append the environment with new data"
++	default n
++	help
++	  If defined, the environment hash table is only ever appended with new
++	  data, but the existing hash table can never be dropped and reloaded
++	  with newly imported data. This may be used in combination with static
++	  flags to e.g. to protect variables which must not be modified.
++
++config ENV_ACCESS_IGNORE_FORCE
++	bool "Block forced environment operations"
++	default n
++	help
++	  If defined, don't allow the -f switch to env set override variable
++	  access flags.
++
+ if SPL_ENV_SUPPORT
+ config SPL_ENV_IS_NOWHERE
+ 	bool "SPL Environment is not stored"
+diff --git a/env/env.c b/env/env.c
+index b9febeca51..42c7d8155e 100644
+--- a/env/env.c
++++ b/env/env.c
+@@ -7,6 +7,9 @@
+ #include <common.h>
+ #include <env.h>
+ #include <env_internal.h>
++#include <log.h>
++#include <linux/bitops.h>
++#include <linux/bug.h>
+ 
+ DECLARE_GLOBAL_DATA_PTR;
+ 
+@@ -100,7 +103,7 @@ static void env_set_inited(enum env_location location)
+ 	 * using the above enum value as the bit index. We need to
+ 	 * make sure that we're not overflowing it.
+ 	 */
+-	BUILD_BUG_ON(ARRAY_SIZE(env_locations) > BITS_PER_LONG);
++	BUILD_BUG_ON(ENVL_COUNT > BITS_PER_LONG);
+ 
+ 	gd->env_has_init |= BIT(location);
+ }
+@@ -128,8 +131,6 @@ __weak enum env_location env_get_location(enum env_operation op, int prio)
+ 	if (prio >= ARRAY_SIZE(env_locations))
+ 		return ENVL_UNKNOWN;
+ 
+-	gd->env_load_prio = prio;
+-
+ 	return env_locations[prio];
+ }
+ 
+@@ -186,9 +187,6 @@ int env_load(void)
+ 	for (prio = 0; (drv = env_driver_lookup(ENVOP_LOAD, prio)); prio++) {
+ 		int ret;
+ 
+-		if (!drv->load)
+-			continue;
+-
+ 		if (!env_has_inited(drv->location))
+ 			continue;
+ 
+@@ -201,7 +199,11 @@ int env_load(void)
+ 		ret = drv->load();
+ 		if (!ret) {
+ 			printf("OK\n");
++			gd->env_load_prio = prio;
++
++#if !CONFIG_IS_ENABLED(ENV_APPEND)
+ 			return 0;
++#endif
+ 		} else if (ret == -ENOMSG) {
+ 			/* Handle "bad CRC" case */
+ 			if (best_prio == -1)
+@@ -224,7 +226,36 @@ int env_load(void)
+ 		debug("Selecting environment with bad CRC\n");
+ 	else
+ 		best_prio = 0;
+-	env_get_location(ENVOP_LOAD, best_prio);
++
++	gd->env_load_prio = best_prio;
++
++	return -ENODEV;
++}
++
++int env_reload(void)
++{
++	struct env_driver *drv;
++
++	drv = env_driver_lookup(ENVOP_LOAD, gd->env_load_prio);
++	if (drv) {
++		int ret;
++
++		printf("Loading Environment from %s... ", drv->name);
++
++		if (!env_has_inited(drv->location)) {
++			printf("not initialized\n");
++			return -ENODEV;
++		}
++
++		ret = drv->load();
++		if (ret)
++			printf("Failed (%d)\n", ret);
++		else
++			printf("OK\n");
++
++		if (!ret)
++			return 0;
++	}
+ 
+ 	return -ENODEV;
+ }
+@@ -237,13 +268,17 @@ int env_save(void)
+ 	if (drv) {
+ 		int ret;
+ 
+-		if (!drv->save)
++		printf("Saving Environment to %s... ", drv->name);
++		if (!drv->save) {
++			printf("not possible\n");
+ 			return -ENODEV;
++		}
+ 
+-		if (!env_has_inited(drv->location))
++		if (!env_has_inited(drv->location)) {
++			printf("not initialized\n");
+ 			return -ENODEV;
++		}
+ 
+-		printf("Saving Environment to %s... ", drv->name);
+ 		ret = drv->save();
+ 		if (ret)
+ 			printf("Failed (%d)\n", ret);
+@@ -312,9 +347,44 @@ int env_init(void)
+ 	return ret;
+ }
+ 
+-#ifndef ENV_IS_EMBEDDED
+-__weak long long env_get_offset(long long defautl_offset)
++int env_select(const char *name)
+ {
+-	return defautl_offset;
++	struct env_driver *drv;
++	const int n_ents = ll_entry_count(struct env_driver, env_driver);
++	struct env_driver *entry;
++	int prio;
++	bool found = false;
++
++	printf("Select Environment on %s: ", name);
++
++	/* search ENV driver by name */
++	drv = ll_entry_start(struct env_driver, env_driver);
++	for (entry = drv; entry != drv + n_ents; entry++) {
++		if (!strcmp(entry->name, name)) {
++			found = true;
++			break;
++		}
++	}
++
++	if (!found) {
++		printf("driver not found\n");
++		return -ENODEV;
++	}
++
++	/* search priority by driver */
++	for (prio = 0; (drv = env_driver_lookup(ENVOP_INIT, prio)); prio++) {
++		if (entry->location == env_get_location(ENVOP_LOAD, prio)) {
++			/* when priority change, reset the ENV flags */
++			if (gd->env_load_prio != prio) {
++				gd->env_load_prio = prio;
++				gd->env_valid = ENV_INVALID;
++				gd->flags &= ~GD_FLG_ENV_DEFAULT;
++			}
++			printf("OK\n");
++			return 0;
++		}
++	}
++	printf("priority not found\n");
++
++	return -ENODEV;
+ }
+-#endif
+diff --git a/lib/hashtable.c b/lib/hashtable.c
+index 907e8a642f..18dfa072bd 100644
+--- a/lib/hashtable.c
++++ b/lib/hashtable.c
+@@ -813,6 +813,10 @@ int himport_r(struct hsearch_data *htab,
+ 	if (nvars)
+ 		memcpy(localvars, vars, sizeof(vars[0]) * nvars);
+ 
++#if CONFIG_IS_ENABLED(ENV_APPEND)
++	flag |= H_NOCLEAR;
++#endif
++
+ 	if ((flag & H_NOCLEAR) == 0 && !nvars) {
+ 		/* Destroy old hash table if one exists */
+ 		debug("Destroy Hash Table: %p table = %p\n", htab,
+-- 
+2.36.1
+

--- a/recipes-bsp/u-boot/u-boot-imx/common/0009-env-Add-support-for-explicit-write-access-list.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/common/0009-env-Add-support-for-explicit-write-access-list.patch
@@ -1,0 +1,231 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Marek Vasut <marex@denx.de>
+Date: Tue, 7 Jul 2020 20:51:39 +0200
+Subject: [PATCH] env: Add support for explicit write access list
+
+This option marks any U-Boot variable which does not have explicit 'w'
+writeable flag set as read-only. This way the environment can be locked
+down and only variables explicitly configured to be writeable can ever
+be changed by either 'env import', 'env set' or loading user environment
+from environment storage.
+
+Signed-off-by: Marek Vasut <marex@denx.de>
+Reviewed-by: Tom Rini <trini@konsulko.com>
+---
+ env/Kconfig         |  8 ++++++
+ env/flags.c         | 62 +++++++++++++++++++++++++++++++++++++--------
+ include/env_flags.h |  6 ++++-
+ lib/hashtable.c     |  5 +++-
+ 4 files changed, 68 insertions(+), 13 deletions(-)
+
+diff --git a/env/Kconfig b/env/Kconfig
+index 1cae1edf6a..5d0a8ecea0 100644
+--- a/env/Kconfig
++++ b/env/Kconfig
+@@ -623,6 +623,14 @@ config ENV_APPEND
+ 	  with newly imported data. This may be used in combination with static
+ 	  flags to e.g. to protect variables which must not be modified.
+ 
++config ENV_WRITEABLE_LIST
++	bool "Permit write access only to listed variables"
++	default n
++	help
++	  If defined, only environment variables which explicitly set the 'w'
++	  writeable flag can be written and modified at runtime. No variables
++	  can be otherwise created, written or imported into the environment.
++
+ config ENV_ACCESS_IGNORE_FORCE
+ 	bool "Block forced environment operations"
+ 	default n
+diff --git a/env/flags.c b/env/flags.c
+index 5a5910c480..c27f4f636b 100644
+--- a/env/flags.c
++++ b/env/flags.c
+@@ -28,8 +28,15 @@
+ #define ENV_FLAGS_NET_VARTYPE_REPS ""
+ #endif
+ 
++#ifdef CONFIG_ENV_WRITEABLE_LIST
++#define ENV_FLAGS_WRITEABLE_VARACCESS_REPS "w"
++#else
++#define ENV_FLAGS_WRITEABLE_VARACCESS_REPS ""
++#endif
++
+ static const char env_flags_vartype_rep[] = "sdxb" ENV_FLAGS_NET_VARTYPE_REPS;
+-static const char env_flags_varaccess_rep[] = "aroc";
++static const char env_flags_varaccess_rep[] =
++	"aroc" ENV_FLAGS_WRITEABLE_VARACCESS_REPS;
+ static const int env_flags_varaccess_mask[] = {
+ 	0,
+ 	ENV_FLAGS_VARACCESS_PREVENT_DELETE |
+@@ -38,7 +45,11 @@ static const int env_flags_varaccess_mask[] = {
+ 	ENV_FLAGS_VARACCESS_PREVENT_DELETE |
+ 		ENV_FLAGS_VARACCESS_PREVENT_OVERWR,
+ 	ENV_FLAGS_VARACCESS_PREVENT_DELETE |
+-		ENV_FLAGS_VARACCESS_PREVENT_NONDEF_OVERWR};
++		ENV_FLAGS_VARACCESS_PREVENT_NONDEF_OVERWR,
++#ifdef CONFIG_ENV_WRITEABLE_LIST
++	ENV_FLAGS_VARACCESS_WRITEABLE,
++#endif
++	};
+ 
+ #ifdef CONFIG_CMD_ENV_FLAGS
+ static const char * const env_flags_vartype_names[] = {
+@@ -56,6 +67,9 @@ static const char * const env_flags_varaccess_names[] = {
+ 	"read-only",
+ 	"write-once",
+ 	"change-default",
++#ifdef CONFIG_ENV_WRITEABLE_LIST
++	"writeable",
++#endif
+ };
+ 
+ /*
+@@ -130,21 +144,25 @@ enum env_flags_vartype env_flags_parse_vartype(const char *flags)
+  */
+ enum env_flags_varaccess env_flags_parse_varaccess(const char *flags)
+ {
++	enum env_flags_varaccess va_default = env_flags_varaccess_any;
++	enum env_flags_varaccess va;
+ 	char *access;
+ 
+ 	if (strlen(flags) <= ENV_FLAGS_VARACCESS_LOC)
+-		return env_flags_varaccess_any;
++		return va_default;
+ 
+ 	access = strchr(env_flags_varaccess_rep,
+ 		flags[ENV_FLAGS_VARACCESS_LOC]);
+ 
+-	if (access != NULL)
+-		return (enum env_flags_varaccess)
++	if (access != NULL) {
++		va = (enum env_flags_varaccess)
+ 			(access - &env_flags_varaccess_rep[0]);
++		return va;
++	}
+ 
+ 	printf("## Warning: Unknown environment variable access method '%c'\n",
+ 		flags[ENV_FLAGS_VARACCESS_LOC]);
+-	return env_flags_varaccess_any;
++	return va_default;
+ }
+ 
+ /*
+@@ -152,17 +170,21 @@ enum env_flags_varaccess env_flags_parse_varaccess(const char *flags)
+  */
+ enum env_flags_varaccess env_flags_parse_varaccess_from_binflags(int binflags)
+ {
++	enum env_flags_varaccess va_default = env_flags_varaccess_any;
++	enum env_flags_varaccess va;
+ 	int i;
+ 
+ 	for (i = 0; i < ARRAY_SIZE(env_flags_varaccess_mask); i++)
+ 		if (env_flags_varaccess_mask[i] ==
+-		    (binflags & ENV_FLAGS_VARACCESS_BIN_MASK))
+-			return (enum env_flags_varaccess)i;
++		    (binflags & ENV_FLAGS_VARACCESS_BIN_MASK)) {
++			va = (enum env_flags_varaccess)i;
++			return va;
++	}
+ 
+ 	printf("Warning: Non-standard access flags. (0x%x)\n",
+ 		binflags & ENV_FLAGS_VARACCESS_BIN_MASK);
+ 
+-	return env_flags_varaccess_any;
++	return va_default;
+ }
+ 
+ static inline int is_hex_prefix(const char *value)
+@@ -326,13 +348,14 @@ enum env_flags_vartype env_flags_get_type(const char *name)
+ enum env_flags_varaccess env_flags_get_varaccess(const char *name)
+ {
+ 	const char *flags_list = env_get(ENV_FLAGS_VAR);
++	enum env_flags_varaccess va_default = env_flags_varaccess_any;
+ 	char flags[ENV_FLAGS_ATTR_MAX_LEN + 1];
+ 
+ 	if (env_flags_lookup(flags_list, name, flags))
+-		return env_flags_varaccess_any;
++		return va_default;
+ 
+ 	if (strlen(flags) <= ENV_FLAGS_VARACCESS_LOC)
+-		return env_flags_varaccess_any;
++		return va_default;
+ 
+ 	return env_flags_parse_varaccess(flags);
+ }
+@@ -426,7 +449,11 @@ void env_flags_init(struct env_entry *var_entry)
+ 	int ret = 1;
+ 
+ 	if (first_call) {
++#ifdef CONFIG_ENV_WRITEABLE_LIST
++		flags_list = ENV_FLAGS_LIST_STATIC;
++#else
+ 		flags_list = env_get(ENV_FLAGS_VAR);
++#endif
+ 		first_call = 0;
+ 	}
+ 	/* look in the ".flags" and static for a reference to this variable */
+@@ -524,6 +551,19 @@ int env_flags_validate(const struct env_entry *item, const char *newval,
+ 	}
+ 
+ 	/* check for access permission */
++#ifdef CONFIG_ENV_WRITEABLE_LIST
++	if (flag & H_DEFAULT)
++		return 0;	/* Default env is always OK */
++
++	/*
++	 * External writeable variables can be overwritten by external env,
++	 * anything else can not be overwritten by external env.
++	 */
++	if ((flag & H_EXTERNAL) &&
++	    !(item->flags & ENV_FLAGS_VARACCESS_WRITEABLE))
++		return 1;
++#endif
++
+ #ifndef CONFIG_ENV_ACCESS_IGNORE_FORCE
+ 	if (flag & H_FORCE) {
+ 		printf("## Error: Can't force access to \"%s\"\n", name);
+diff --git a/include/env_flags.h b/include/env_flags.h
+index 725841a891..313cb8c49a 100644
+--- a/include/env_flags.h
++++ b/include/env_flags.h
+@@ -24,6 +24,9 @@ enum env_flags_varaccess {
+ 	env_flags_varaccess_readonly,
+ 	env_flags_varaccess_writeonce,
+ 	env_flags_varaccess_changedefault,
++#ifdef CONFIG_ENV_WRITEABLE_LIST
++	env_flags_varaccess_writeable,
++#endif
+ 	env_flags_varaccess_end
+ };
+ 
+@@ -173,6 +176,7 @@ int env_flags_validate(const struct env_entry *item, const char *newval,
+ #define ENV_FLAGS_VARACCESS_PREVENT_CREATE		0x00000010
+ #define ENV_FLAGS_VARACCESS_PREVENT_OVERWR		0x00000020
+ #define ENV_FLAGS_VARACCESS_PREVENT_NONDEF_OVERWR	0x00000040
+-#define ENV_FLAGS_VARACCESS_BIN_MASK			0x00000078
++#define ENV_FLAGS_VARACCESS_WRITEABLE			0x00000080
++#define ENV_FLAGS_VARACCESS_BIN_MASK			0x000000f8
+ 
+ #endif /* __ENV_FLAGS_H__ */
+diff --git a/lib/hashtable.c b/lib/hashtable.c
+index 18dfa072bd..f9841807fc 100644
+--- a/lib/hashtable.c
++++ b/lib/hashtable.c
+@@ -937,9 +937,12 @@ int himport_r(struct hsearch_data *htab,
+ 		e.data = value;
+ 
+ 		hsearch_r(e, ENV_ENTER, &rv, htab, flag);
+-		if (rv == NULL)
++#if !CONFIG_IS_ENABLED(ENV_WRITEABLE_LIST)
++		if (rv == NULL) {
+ 			printf("himport_r: can't insert \"%s=%s\" into hash table\n",
+ 				name, value);
++		}
++#endif
+ 
+ 		debug("INSERT: table %p, filled %d/%d rv %p ==> name=\"%s\" value=\"%s\"\n",
+ 			htab, htab->filled, htab->size,
+-- 
+2.36.1
+

--- a/recipes-bsp/u-boot/u-boot-imx/common/0010-env-nowhere-add-.load-ops.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/common/0010-env-nowhere-add-.load-ops.patch
@@ -1,0 +1,48 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Patrick Delaunay <patrick.delaunay@st.com>
+Date: Tue, 28 Jul 2020 11:51:18 +0200
+Subject: [PATCH] env: nowhere: add .load ops
+
+Add the ops .load for nowhere ENV backend to load the
+default environment.
+
+This ops is needed for the command 'env load'
+
+Signed-off-by: Patrick Delaunay <patrick.delaunay@st.com>
+---
+ env/nowhere.c | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+diff --git a/env/nowhere.c b/env/nowhere.c
+index f5b0a17652..d33fdf27d0 100644
+--- a/env/nowhere.c
++++ b/env/nowhere.c
+@@ -27,8 +27,25 @@ static int env_nowhere_init(void)
+ 	return 0;
+ }
+ 
++static int env_nowhere_load(void)
++{
++	/*
++	 * for SPL, set env_valid = ENV_INVALID is enougth as env_get_char()
++	 * return the default env if env_get is used
++	 * and SPL don't used env_import to reduce its size
++	 * For U-Boot proper, import the default environment to allow reload.
++	 */
++	if (!IS_ENABLED(CONFIG_SPL_BUILD))
++		env_set_default(NULL, 0);
++
++	gd->env_valid	= ENV_INVALID;
++
++	return 0;
++}
++
+ U_BOOT_ENV_LOCATION(nowhere) = {
+ 	.location	= ENVL_NOWHERE,
+ 	.init		= env_nowhere_init,
++	.load		= env_nowhere_load,
+ 	ENV_NAME("nowhere")
+ };
+-- 
+2.36.1
+

--- a/recipes-bsp/u-boot/u-boot-imx/common/0011-env-Fix-warning-when-forcing-environment-without-ENV.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/common/0011-env-Fix-warning-when-forcing-environment-without-ENV.patch
@@ -1,0 +1,64 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Martin Fuzzey <martin.fuzzey@flowbird.group>
+Date: Mon, 11 Jan 2021 11:27:20 +0100
+Subject: [PATCH] env: Fix warning when forcing environment without
+ ENV_ACCESS_IGNORE_FORCE
+
+Since commit 0f036bf4b87e ("env: Warn on force access if ENV_ACCESS_IGNORE_FORCE set")
+a warning message is displayed when setenv -f is used WITHOUT
+CONFIG_ENV_ACCESS_IGNORE_FORCE, but the variable is set anyway, resulting
+in lots of log pollution.
+
+env_flags_validate() returns 0 if the access is accepted, or non zero
+if it is refused.
+
+So the original code
+	#ifndef CONFIG_ENV_ACCESS_IGNORE_FORCE
+		if (flag & H_FORCE)
+			return 0;
+	#endif
+
+was correct, it returns 0 (accepts the modification) if forced UNLESS
+IGNORE_FORCE is set (in which case access checks in the following code
+are applied). The broken patch just added a printf to the force accepted
+case.
+
+To obtain the intent of the patch we need this:
+	if (flag & H_FORCE) {
+	#ifdef CONFIG_ENV_ACCESS_IGNORE_FORCE
+		printf("## Error: Can't force access to \"%s\"\n", name);
+	#else
+		return 0;
+	#endif
+	}
+
+Fixes: 0f036bf4b87e ("env: Warn on force access if ENV_ACCESS_IGNORE_FORCE set")
+
+Signed-off-by: Martin Fuzzey <martin.fuzzey@flowbird.group>
+---
+ env/flags.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/env/flags.c b/env/flags.c
+index c27f4f636b..0b90ef9534 100644
+--- a/env/flags.c
++++ b/env/flags.c
+@@ -564,12 +564,13 @@ int env_flags_validate(const struct env_entry *item, const char *newval,
+ 		return 1;
+ #endif
+ 
+-#ifndef CONFIG_ENV_ACCESS_IGNORE_FORCE
+ 	if (flag & H_FORCE) {
++#ifdef CONFIG_ENV_ACCESS_IGNORE_FORCE
+ 		printf("## Error: Can't force access to \"%s\"\n", name);
++#else
+ 		return 0;
+-	}
+ #endif
++	}
+ 	switch (op) {
+ 	case env_op_delete:
+ 		if (item->flags & ENV_FLAGS_VARACCESS_PREVENT_DELETE) {
+-- 
+2.36.1
+

--- a/recipes-bsp/u-boot/u-boot-imx/common/0012-env-split-env_import_redund-into-2-functions.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/common/0012-env-split-env_import_redund-into-2-functions.patch
@@ -1,0 +1,136 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Heiko Schocher <hs@denx.de>
+Date: Sat, 10 Oct 2020 10:28:04 +0200
+Subject: [PATCH] env: split env_import_redund() into 2 functions
+
+split from env_import_redund() the part which checks
+which Environment is valid into a separate function
+called env_check_redund() and call it from env_import_redund().
+
+So env_check_redund() can be used from places which also
+need to do this checks.
+
+Signed-off-by: Heiko Schocher <hs@denx.de>
+Reviewed-by: Simon Glass <sjg@chromium.org>
+---
+ env/common.c  | 42 ++++++++++++++++++++++++++++++++----------
+ include/env.h | 18 ++++++++++++++++++
+ 2 files changed, 50 insertions(+), 10 deletions(-)
+
+diff --git a/env/common.c b/env/common.c
+index d70274d903..24d4b3f866 100644
+--- a/env/common.c
++++ b/env/common.c
+@@ -139,12 +139,11 @@ int env_import(const char *buf, int check, int flags)
+ #ifdef CONFIG_SYS_REDUNDAND_ENVIRONMENT
+ static unsigned char env_flags;
+ 
+-int env_import_redund(const char *buf1, int buf1_read_fail,
+-		      const char *buf2, int buf2_read_fail,
+-		      int flags)
++int env_check_redund(const char *buf1, int buf1_read_fail,
++		     const char *buf2, int buf2_read_fail)
+ {
+ 	int crc1_ok, crc2_ok;
+-	env_t *ep, *tmp_env1, *tmp_env2;
++	env_t *tmp_env1, *tmp_env2;
+ 
+ 	tmp_env1 = (env_t *)buf1;
+ 	tmp_env2 = (env_t *)buf2;
+@@ -157,14 +156,13 @@ int env_import_redund(const char *buf1, int buf1_read_fail,
+ 	}
+ 
+ 	if (buf1_read_fail && buf2_read_fail) {
+-		env_set_default("bad env area", 0);
+ 		return -EIO;
+ 	} else if (!buf1_read_fail && buf2_read_fail) {
+ 		gd->env_valid = ENV_VALID;
+-		return env_import((char *)tmp_env1, 1, flags);
++		return -EINVAL;
+ 	} else if (buf1_read_fail && !buf2_read_fail) {
+ 		gd->env_valid = ENV_REDUND;
+-		return env_import((char *)tmp_env2, 1, flags);
++		return -ENOENT;
+ 	}
+ 
+ 	crc1_ok = crc32(0, tmp_env1->data, ENV_SIZE) ==
+@@ -173,7 +171,6 @@ int env_import_redund(const char *buf1, int buf1_read_fail,
+ 			tmp_env2->crc;
+ 
+ 	if (!crc1_ok && !crc2_ok) {
+-		env_set_default("bad CRC", 0);
+ 		return -ENOMSG; /* needed for env_load() */
+ 	} else if (crc1_ok && !crc2_ok) {
+ 		gd->env_valid = ENV_VALID;
+@@ -193,12 +190,37 @@ int env_import_redund(const char *buf1, int buf1_read_fail,
+ 			gd->env_valid = ENV_VALID;
+ 	}
+ 
++	return 0;
++}
++
++int env_import_redund(const char *buf1, int buf1_read_fail,
++		      const char *buf2, int buf2_read_fail,
++		      int flags)
++{
++	env_t *ep;
++	int ret;
++
++	ret = env_check_redund(buf1, buf1_read_fail, buf2, buf2_read_fail);
++
++	if (ret == -EIO) {
++		env_set_default("bad env area", 0);
++		return -EIO;
++	} else if (ret == -EINVAL) {
++		return env_import((char *)buf1, 1, flags);
++	} else if (ret == -ENOENT) {
++		return env_import((char *)buf2, 1, flags);
++	} else if (ret == -ENOMSG) {
++		env_set_default("bad CRC", 0);
++		return -ENOMSG;
++	}
++
+ 	if (gd->env_valid == ENV_VALID)
+-		ep = tmp_env1;
++		ep = (env_t *)buf1;
+ 	else
+-		ep = tmp_env2;
++		ep = (env_t *)buf2;
+ 
+ 	env_flags = ep->flags;
++
+ 	return env_import((char *)ep, 0, flags);
+ }
+ #endif /* CONFIG_SYS_REDUNDAND_ENVIRONMENT */
+diff --git a/include/env.h b/include/env.h
+index 0176a04879..dbf8fa0494 100644
+--- a/include/env.h
++++ b/include/env.h
+@@ -304,6 +304,24 @@ int env_import(const char *buf, int check, int flags);
+  */
+ int env_export(struct environment_s *env_out);
+ 
++/**
++ * env_check_redund() - check the two redundant environments
++ *   and find out, which is the valid one.
++ *
++ * @buf1: First environment (struct environemnt_s *)
++ * @buf1_read_fail: 0 if buf1 is valid, non-zero if invalid
++ * @buf2: Second environment (struct environemnt_s *)
++ * @buf2_read_fail: 0 if buf2 is valid, non-zero if invalid
++ * @return 0 if OK,
++ *	-EIO if no environment is valid,
++ *	-EINVAL if read of second entry is good
++ *	-ENOENT if read of first entry is good
++ *	-ENOMSG if the CRC was bad
++ */
++
++int env_check_redund(const char *buf1, int buf1_read_fail,
++		     const char *buf2, int buf2_read_fail);
++
+ /**
+  * env_import_redund() - Select and import one of two redundant environments
+  *
+-- 
+2.36.1
+

--- a/recipes-bsp/u-boot/u-boot-imx/common/0013-env-increment-redund-flag-on-read-fail.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/common/0013-env-increment-redund-flag-on-read-fail.patch
@@ -1,0 +1,104 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Brandon Maier <brandon.maier@rockwellcollins.com>
+Date: Thu, 17 Dec 2020 17:19:18 -0600
+Subject: [PATCH] env: increment redund flag on read fail
+
+If one of the reads fails when importing redundant environments (a
+single read failure), the env_flags wouldn't get initialized in
+env_import_redund(). If a user then calls saveenv, the new environment
+will have the wrong flags value. So on the next load the new environment
+will be ignored.
+
+While debugging this, I also noticed that env/sf.c was not correctly
+handling a single read failure, as it would not check the crc before
+assigning it to gd->env_addr.
+
+Having a special error path for when there is a single read failure
+seems unnecessary and may lead to future bugs. Instead collapse the
+'single read failure' error to be the same as a 'single crc failure'.
+That way env_check_redund() either passes or fails, and if it passes we
+are guaranteed to have checked the CRC.
+
+Signed-off-by: Brandon Maier <brandon.maier@rockwellcollins.com>
+CC: Joe Hershberger <joe.hershberger@ni.com>
+CC: Wolfgang Denk <wd@denx.de>
+CC: Heiko Schocher <hs@denx.de>
+Reviewed-by: Tom Rini <trini@konsulko.com>
+---
+ env/common.c  | 27 ++++++++-------------------
+ include/env.h |  2 --
+ 2 files changed, 8 insertions(+), 21 deletions(-)
+
+diff --git a/env/common.c b/env/common.c
+index 24d4b3f866..e6e82e7363 100644
+--- a/env/common.c
++++ b/env/common.c
+@@ -142,7 +142,7 @@ static unsigned char env_flags;
+ int env_check_redund(const char *buf1, int buf1_read_fail,
+ 		     const char *buf2, int buf2_read_fail)
+ {
+-	int crc1_ok, crc2_ok;
++	int crc1_ok = 0, crc2_ok = 0;
+ 	env_t *tmp_env1, *tmp_env2;
+ 
+ 	tmp_env1 = (env_t *)buf1;
+@@ -150,25 +150,18 @@ int env_check_redund(const char *buf1, int buf1_read_fail,
+ 
+ 	if (buf1_read_fail && buf2_read_fail) {
+ 		puts("*** Error - No Valid Environment Area found\n");
++		return -EIO;
+ 	} else if (buf1_read_fail || buf2_read_fail) {
+ 		puts("*** Warning - some problems detected ");
+ 		puts("reading environment; recovered successfully\n");
+ 	}
+ 
+-	if (buf1_read_fail && buf2_read_fail) {
+-		return -EIO;
+-	} else if (!buf1_read_fail && buf2_read_fail) {
+-		gd->env_valid = ENV_VALID;
+-		return -EINVAL;
+-	} else if (buf1_read_fail && !buf2_read_fail) {
+-		gd->env_valid = ENV_REDUND;
+-		return -ENOENT;
+-	}
+-
+-	crc1_ok = crc32(0, tmp_env1->data, ENV_SIZE) ==
+-			tmp_env1->crc;
+-	crc2_ok = crc32(0, tmp_env2->data, ENV_SIZE) ==
+-			tmp_env2->crc;
++	if (!buf1_read_fail)
++		crc1_ok = crc32(0, tmp_env1->data, ENV_SIZE) ==
++				tmp_env1->crc;
++	if (!buf2_read_fail)
++		crc2_ok = crc32(0, tmp_env2->data, ENV_SIZE) ==
++				tmp_env2->crc;
+ 
+ 	if (!crc1_ok && !crc2_ok) {
+ 		return -ENOMSG; /* needed for env_load() */
+@@ -205,10 +198,6 @@ int env_import_redund(const char *buf1, int buf1_read_fail,
+ 	if (ret == -EIO) {
+ 		env_set_default("bad env area", 0);
+ 		return -EIO;
+-	} else if (ret == -EINVAL) {
+-		return env_import((char *)buf1, 1, flags);
+-	} else if (ret == -ENOENT) {
+-		return env_import((char *)buf2, 1, flags);
+ 	} else if (ret == -ENOMSG) {
+ 		env_set_default("bad CRC", 0);
+ 		return -ENOMSG;
+diff --git a/include/env.h b/include/env.h
+index dbf8fa0494..5291555533 100644
+--- a/include/env.h
++++ b/include/env.h
+@@ -314,8 +314,6 @@ int env_export(struct environment_s *env_out);
+  * @buf2_read_fail: 0 if buf2 is valid, non-zero if invalid
+  * @return 0 if OK,
+  *	-EIO if no environment is valid,
+- *	-EINVAL if read of second entry is good
+- *	-ENOENT if read of first entry is good
+  *	-ENOMSG if the CRC was bad
+  */
+ 
+-- 
+2.36.1
+

--- a/recipes-bsp/u-boot/u-boot-imx/common/0014-env-Fix-invalid-env-handling-in-env_init.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/common/0014-env-Fix-invalid-env-handling-in-env_init.patch
@@ -1,0 +1,45 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Marek Vasut <marex@denx.de>
+Date: Wed, 20 Jan 2021 15:45:16 +0100
+Subject: [PATCH] env: Fix invalid env handling in env_init()
+
+This fixes the case where there are multiple environment drivers, one of
+them is the default environment one, and it is followed by an environment
+driver which does not implement .init() callback. The default environment
+driver sets gd->env_valid to ENV_INVALID and returns 0 from its .init()
+callback implementation, which is valid behavior for default environment.
+
+Since the subsequent environment driver does not implement .init(), it
+also does not modify the $ret variable in the loop. Therefore, the loop
+is exited with gd->env_valid=ENV_INVALID and ret=0, which means that the
+code further down in env_init() will not reset the environment to the
+default one, which is incorrect.
+
+This patch sets the $ret variable back to -ENOENT in case the env_valid
+is set to ENV_INVALID by an environment driver, so that the environment
+would be correctly reset back to default one, unless a subsequent driver
+loads a valid environment.
+
+Signed-off-by: Marek Vasut <marex@denx.de>
+Tested-By: Tim Harvey <tharvey@gateworks.com>
+---
+ env/env.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/env/env.c b/env/env.c
+index 42c7d8155e..4dacd3dd63 100644
+--- a/env/env.c
++++ b/env/env.c
+@@ -332,6 +332,9 @@ int env_init(void)
+ 
+ 		debug("%s: Environment %s init done (ret=%d)\n", __func__,
+ 		      drv->name, ret);
++
++		if (gd->env_valid == ENV_INVALID)
++			ret = -ENOENT;
+ 	}
+ 
+ 	if (!prio)
+-- 
+2.36.1
+

--- a/recipes-bsp/u-boot/u-boot-imx/common/0015-env-Fix-prio-on-bad-CRC-case-with-ENV_APPEND-enabled.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/common/0015-env-Fix-prio-on-bad-CRC-case-with-ENV_APPEND-enabled.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michael Glembotzki <Michael.Glembotzki@iris-sensing.com>
+Date: Tue, 14 Jun 2022 12:26:39 +0200
+Subject: [PATCH] env: Fix prio on bad CRC case with ENV_APPEND enabled
+
+Under no circumstances the environments with bad crc from the emmc are trusted.
+The highest priority should always set to "0". See env_get_location() in
+imx8m/soc.c for further information.
+
+Signed-off-by: Michael Glembotzki <Michael.Glembotzki@iris-sensing.com>
+---
+ env/env.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/env/env.c b/env/env.c
+index 4dacd3dd63..d0bdef9dca 100644
+--- a/env/env.c
++++ b/env/env.c
+@@ -203,11 +203,11 @@ int env_load(void)
+ 
+ #if !CONFIG_IS_ENABLED(ENV_APPEND)
+ 			return 0;
+-#endif
+ 		} else if (ret == -ENOMSG) {
+ 			/* Handle "bad CRC" case */
+ 			if (best_prio == -1)
+ 				best_prio = prio;
++#endif
+ 		} else {
+ 			debug("Failed (%d)\n", ret);
+ 		}
+-- 
+2.36.1
+

--- a/recipes-bsp/u-boot/u-boot-imx/common/0016-env-Invert-gd-env_valid-for-env_mmc_save.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/common/0016-env-Invert-gd-env_valid-for-env_mmc_save.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michael Glembotzki <Michael.Glembotzki@iris-sensing.com>
+Date: Tue, 14 Jun 2022 20:45:14 +0200
+Subject: [PATCH] env: Invert gd->env_valid for env_mmc_save
+
+The A/B update strategy of the env's has a gap in the first 2 calls of saveenv.
+The env's are stored twice on the first memory area if:
+gd->env_valid == ENV_INVALID.
+
+u-boot=> saveenv
+Saving Environment to MMC... Writing to MMC(1)... OK
+u-boot=> saveenv
+Saving Environment to MMC... Writing to MMC(1)... OK  <-- !!!
+u-boot=> saveenv
+Saving Environment to MMC... Writing to redundant MMC(1)... OK
+u-boot=> saveenv
+Saving Environment to MMC... Writing to MMC(1)... OK
+
+Signed-off-by: Michael Glembotzki <Michael.Glembotzki@iris-sensing.com>
+---
+ env/mmc.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/env/mmc.c b/env/mmc.c
+index 7833404cd1..e6b51a1ffa 100644
+--- a/env/mmc.c
++++ b/env/mmc.c
+@@ -227,7 +227,7 @@ static int env_mmc_save(void)
+ 	ret = 0;
+ 
+ #ifdef CONFIG_ENV_OFFSET_REDUND
+-	gd->env_valid = gd->env_valid == ENV_REDUND ? ENV_VALID : ENV_REDUND;
++	gd->env_valid = gd->env_valid == ENV_VALID ? ENV_REDUND : ENV_VALID;
+ #endif
+ 
+ fini:
+-- 
+2.36.1
+

--- a/recipes-bsp/u-boot/u-boot-imx/common/0017-imx8m-soc.c-Use-arch-specific-env_get_location.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/common/0017-imx8m-soc.c-Use-arch-specific-env_get_location.patch
@@ -1,0 +1,78 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michael Glembotzki <Michael.Glembotzki@iris-sensing.com>
+Date: Fri, 10 Jun 2022 21:11:55 +0200
+Subject: [PATCH] imx8m/soc.c: Use arch specific env_get_location
+
+To restrict the "writable" u-boot envs (ENV_WRITELIST) a usecase specific
+function env_get_location is needed:
+
+The env location when saving:
+0. EMMC
+
+The env location when loading and all other cases:
+0. NOWHERE (default envs) and is appended by the filtered envs from the
+1. EMMC
+
+Signed-off-by: Michael Glembotzki <Michael.Glembotzki@iris-sensing.com>
+---
+ arch/arm/mach-imx/imx8m/soc.c | 43 ++++++++---------------------------
+ 1 file changed, 9 insertions(+), 34 deletions(-)
+
+diff --git a/arch/arm/mach-imx/imx8m/soc.c b/arch/arm/mach-imx/imx8m/soc.c
+index e71b3755c4..5bbe7bce42 100644
+--- a/arch/arm/mach-imx/imx8m/soc.c
++++ b/arch/arm/mach-imx/imx8m/soc.c
+@@ -1213,41 +1213,16 @@ void do_error(struct pt_regs *pt_regs, unsigned int esr)
+ #if defined(CONFIG_IMX8MN) || defined(CONFIG_IMX8MP)
+ enum env_location env_get_location(enum env_operation op, int prio)
+ {
+-	enum boot_device dev = get_boot_device();
+-	enum env_location env_loc = ENVL_UNKNOWN;
+-
+-	if (prio)
+-		return env_loc;
+-
+-	switch (dev) {
+-#ifdef CONFIG_ENV_IS_IN_SPI_FLASH
+-	case QSPI_BOOT:
+-		env_loc = ENVL_SPI_FLASH;
+-		break;
+-#endif
+-#ifdef CONFIG_ENV_IS_IN_NAND
+-	case NAND_BOOT:
+-		env_loc = ENVL_NAND;
+-		break;
+-#endif
+-#ifdef CONFIG_ENV_IS_IN_MMC
+-	case SD1_BOOT:
+-	case SD2_BOOT:
+-	case SD3_BOOT:
+-	case MMC1_BOOT:
+-	case MMC2_BOOT:
+-	case MMC3_BOOT:
+-		env_loc =  ENVL_MMC;
+-		break;
+-#endif
+-	default:
+-#if defined(CONFIG_ENV_IS_NOWHERE)
+-		env_loc = ENVL_NOWHERE;
+-#endif
+-		break;
++	if (op == ENVOP_SAVE) {
++		if (prio == 0)
++			return ENVL_MMC;
++	} else {
++		if (prio == 0)
++			return ENVL_NOWHERE;
++		if (prio == 1)
++			return ENVL_MMC;
+ 	}
+-
+-	return env_loc;
++	return ENVL_UNKNOWN;
+ }
+ 
+ #ifndef ENV_IS_EMBEDDED
+-- 
+2.36.1
+

--- a/recipes-bsp/u-boot/u-boot-imx/imx8mp-irma6r2/0022-imx8mp-irma6r2-Add-CONFIG_ENV_FLAGS_LIST_STATIC.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/imx8mp-irma6r2/0022-imx8mp-irma6r2-Add-CONFIG_ENV_FLAGS_LIST_STATIC.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michael Glembotzki <Michael.Glembotzki@iris-sensing.com>
+Date: Tue, 7 Jun 2022 14:40:49 +0200
+Subject: [PATCH] imx8mp-irma6r2: Add CONFIG_ENV_FLAGS_LIST_STATIC
+
+Reduce writable u-boot-env's to a minimum
+
+Signed-off-by: Michael Glembotzki <Michael.Glembotzki@iris-sensing.com>
+---
+ include/configs/imx8mp_irma6r2.h | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/include/configs/imx8mp_irma6r2.h b/include/configs/imx8mp_irma6r2.h
+index 58121b4cbe..86254aabd0 100644
+--- a/include/configs/imx8mp_irma6r2.h
++++ b/include/configs/imx8mp_irma6r2.h
+@@ -86,6 +86,14 @@
+ #define MFG_NAND_PARTITION "mtdparts=gpmi-nand:64m(nandboot),16m(nandfit),32m(nandkernel),16m(nanddtb),8m(nandtee),-(nandrootfs)"
+ #endif
+ 
++/* Limit write access to a minimum*/
++#define CONFIG_ENV_FLAGS_LIST_STATIC \
++       "upgrade_available:dw," \
++       "bootcount:dw," \
++       "ustate:dw," \
++       "firmware:dw"
++
++
+ /* Initial environment variables */
+ #if defined(CONFIG_NAND_BOOT)
+ #define CONFIG_EXTRA_ENV_SETTINGS \
+-- 
+2.36.1
+

--- a/recipes-bsp/u-boot/u-boot-imx/imx8mp-irma6r2/0023-imx8mp-irma6r2-Add-reset-after-bootcmd.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/imx8mp-irma6r2/0023-imx8mp-irma6r2-Add-reset-after-bootcmd.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michael Glembotzki <Michael.Glembotzki@iris-sensing.com>
+Date: Wed, 8 Jun 2022 08:29:14 +0200
+Subject: [PATCH] imx8mp-irma6r2: Add reset after bootcmd
+
+The 'reset' at the end of the bootcmd ensures that a boot failure does not
+drop into an insecure U-boot console.
+
+Signed-off-by: Michael Glembotzki <Michael.Glembotzki@iris-sensing.com>
+---
+ include/configs/imx8mp_irma6r2.h | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/include/configs/imx8mp_irma6r2.h b/include/configs/imx8mp_irma6r2.h
+index 86254aabd0..19dedf196d 100644
+--- a/include/configs/imx8mp_irma6r2.h
++++ b/include/configs/imx8mp_irma6r2.h
+@@ -169,7 +169,9 @@
+ 			"fi; " \
+ 		"fi;\0"
+ 
+-#define CONFIG_BOOTCOMMAND "run fitboot;"
++/* Note the 'reset' at the end of the bootcmd. This is to ensure that a failure
++   to boot does not drop you into an insecure U-boot console */
++#define CONFIG_BOOTCOMMAND "run fitboot; reset;"
+ 
+ #endif
+ 
+-- 
+2.36.1
+

--- a/recipes-bsp/u-boot/u-boot-imx/imx8mp-irma6r2/0024-imx8mp_irma6r2_defconfig-Configure-writeable-list-su.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/imx8mp-irma6r2/0024-imx8mp_irma6r2_defconfig-Configure-writeable-list-su.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michael Glembotzki <Michael.Glembotzki@iris-sensing.com>
+Date: Tue, 14 Jun 2022 08:58:21 +0200
+Subject: [PATCH] imx8mp_irma6r2_defconfig: Configure writeable list support
+
+Configure the env writable list supporti: CONFIG_ENV_WRITEABLE_LIST. To read
+from two sources (nowhere and mmc) the configuration CONFIG_ENV_APPEND must be
+enabled. CONFIG_ENV_ACCESS_IGNORE_FORCE prevents force writing. Also activate
+the u-boot version variable: CONFIG_VERSION_VARIABLE.
+
+Signed-off-by: Michael Glembotzki <Michael.Glembotzki@iris-sensing.com>
+---
+ configs/imx8mp_irma6r2_defconfig | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/configs/imx8mp_irma6r2_defconfig b/configs/imx8mp_irma6r2_defconfig
+index fc52e601cd..6aa47245f1 100644
+--- a/configs/imx8mp_irma6r2_defconfig
++++ b/configs/imx8mp_irma6r2_defconfig
+@@ -32,6 +32,7 @@ CONFIG_OF_BOARD_SETUP=y
+ CONFIG_OF_SYSTEM_SETUP=y
+ CONFIG_SYS_EXTRA_OPTIONS="IMX_CONFIG=arch/arm/mach-imx/imx8m/imximage-8mp-ddr4.cfg"
+ CONFIG_DEFAULT_FDT_FILE="imx8mp-irma6r2.dtb"
++CONFIG_VERSION_VARIABLE=y
+ CONFIG_BOARD_LATE_INIT=y
+ CONFIG_ARCH_MISC_INIT=y
+ CONFIG_BOARD_EARLY_INIT_F=y
+@@ -74,6 +75,9 @@ CONFIG_ENV_IS_IN_MMC=y
+ CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
+ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
+ CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
++CONFIG_ENV_APPEND=y
++CONFIG_ENV_WRITEABLE_LIST=y
++CONFIG_ENV_ACCESS_IGNORE_FORCE=y
+ CONFIG_NET_RANDOM_ETHADDR=y
+ CONFIG_REGMAP=y
+ CONFIG_SYSCON=y
+-- 
+2.36.1
+

--- a/recipes-bsp/u-boot/u-boot-imx/imx8mpevk/0011-imx8mpevk-Add-reset-after-bootcmd.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/imx8mpevk/0011-imx8mpevk-Add-reset-after-bootcmd.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michael Glembotzki <Michael.Glembotzki@iris-sensing.com>
+Date: Tue, 14 Jun 2022 08:19:39 +0200
+Subject: [PATCH] imx8mpevk: Add reset after bootcmd
+
+The 'reset' at the end of the bootcmd ensures that a boot failure does not
+drop into an insecure U-boot console.
+
+Signed-off-by: Michael Glembotzki <Michael.Glembotzki@iris-sensing.com>
+---
+ include/configs/imx8mp_evk.h | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/include/configs/imx8mp_evk.h b/include/configs/imx8mp_evk.h
+index 7637c47d2d..507f4104ed 100644
+--- a/include/configs/imx8mp_evk.h
++++ b/include/configs/imx8mp_evk.h
+@@ -151,7 +151,9 @@
+ 			"fi; " \
+ 		"fi;\0"
+ 
+-#define CONFIG_BOOTCOMMAND "run fitboot;"
++/* Note the 'reset' at the end of the bootcmd. This is to ensure that a failure
++   to boot does not drop you into an insecure U-boot console */
++#define CONFIG_BOOTCOMMAND "run fitboot; reset;"
+ 
+ /* Link Definitions */
+ #define CONFIG_LOADADDR			0x40480000
+-- 
+2.36.1
+

--- a/recipes-bsp/u-boot/u-boot-imx/imx8mpevk/0012-imx8mp-evk-Add-CONFIG_ENV_FLAGS_LIST_STATIC.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/imx8mpevk/0012-imx8mp-evk-Add-CONFIG_ENV_FLAGS_LIST_STATIC.patch
@@ -1,0 +1,33 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michael Glembotzki <Michael.Glembotzki@iris-sensing.com>
+Date: Tue, 7 Jun 2022 14:40:17 +0200
+Subject: [PATCH] imx8mp-evk: Add CONFIG_ENV_FLAGS_LIST_STATIC
+
+Reduce writable u-boot-env's to a minimum
+
+Signed-off-by: Michael Glembotzki <Michael.Glembotzki@iris-sensing.com>
+---
+ include/configs/imx8mp_evk.h | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/include/configs/imx8mp_evk.h b/include/configs/imx8mp_evk.h
+index 507f4104ed..57f7f7c98d 100644
+--- a/include/configs/imx8mp_evk.h
++++ b/include/configs/imx8mp_evk.h
+@@ -93,6 +93,13 @@
+ 	"upgrade_available=0\0" \
+ 	"ustate=0\0" \
+ 
++/* Limit write access to a minimum*/
++#define CONFIG_ENV_FLAGS_LIST_STATIC \
++	"upgrade_available:dw," \
++	"bootcount:dw," \
++	"ustate:dw," \
++	"firmware:dw"
++
+ /* Initial environment variables */
+ #define CONFIG_EXTRA_ENV_SETTINGS		\
+ 	CONFIG_MFG_ENV_SETTINGS \
+-- 
+2.36.1
+

--- a/recipes-bsp/u-boot/u-boot-imx/imx8mpevk/0013-imx8mp_evk_defconfig-Configure-writeable-list-suppor.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/imx8mpevk/0013-imx8mp_evk_defconfig-Configure-writeable-list-suppor.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michael Glembotzki <Michael.Glembotzki@iris-sensing.com>
+Date: Wed, 15 Jun 2022 21:55:11 +0200
+Subject: [PATCH] imx8mp_evk_defconfig: Configure writeable list support
+
+Configure the env writable list supporti: CONFIG_ENV_WRITEABLE_LIST. To read
+from two sources (nowhere and mmc) the configuration CONFIG_ENV_APPEND must be
+enabled. CONFIG_ENV_ACCESS_IGNORE_FORCE prevents force writing. Also activate
+the u-boot version variable: CONFIG_VERSION_VARIABLE.
+
+Signed-off-by: Michael Glembotzki <Michael.Glembotzki@iris-sensing.com>
+---
+ configs/imx8mp_evk_defconfig | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/configs/imx8mp_evk_defconfig b/configs/imx8mp_evk_defconfig
+index 8029d831b1..a4f414661f 100644
+--- a/configs/imx8mp_evk_defconfig
++++ b/configs/imx8mp_evk_defconfig
+@@ -33,6 +33,7 @@ CONFIG_OF_BOARD_SETUP=y
+ CONFIG_OF_SYSTEM_SETUP=y
+ CONFIG_SYS_EXTRA_OPTIONS="IMX_CONFIG=arch/arm/mach-imx/imx8m/imximage-8mp-lpddr4.cfg"
+ CONFIG_DEFAULT_FDT_FILE="imx8mp-evk.dtb"
++CONFIG_VERSION_VARIABLE=y
+ CONFIG_BOARD_LATE_INIT=y
+ CONFIG_ARCH_MISC_INIT=y
+ CONFIG_BOARD_EARLY_INIT_F=y
+@@ -71,6 +72,9 @@ CONFIG_ENV_IS_IN_MMC=y
+ CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
+ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
+ CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
++CONFIG_ENV_APPEND=y
++CONFIG_ENV_WRITEABLE_LIST=y
++CONFIG_ENV_ACCESS_IGNORE_FORCE=y
+ CONFIG_REGMAP=y
+ CONFIG_SYSCON=y
+ CONFIG_BOOTCOUNT_LIMIT=y
+-- 
+2.36.1
+

--- a/recipes-bsp/u-boot/u-boot-imx_iris.inc
+++ b/recipes-bsp/u-boot/u-boot-imx_iris.inc
@@ -9,6 +9,19 @@ SRC_URI_append = "\
 	file://0002-Backport-part-Give-several-functions-more-useful-ret.patch\
 	file://0003-Add-HAB-image-authentication-for-FIT-Images.patch \
 	file://0004-MLK-23089-crypto-fsl_caam-add-rng-prediction-resista.patch \
+	file://0005-env-Warn-on-force-access-if-ENV_ACCESS_IGNORE_FORCE-.patch \
+	file://0006-env-Add-H_DEFAULT-flag.patch \
+	file://0007-env-Discern-environment-coming-from-external-storage.patch \
+	file://0008-env-Add-option-to-only-ever-append-environment.patch \
+	file://0009-env-Add-support-for-explicit-write-access-list.patch \
+	file://0010-env-nowhere-add-.load-ops.patch \
+	file://0011-env-Fix-warning-when-forcing-environment-without-ENV.patch \
+	file://0012-env-split-env_import_redund-into-2-functions.patch \
+	file://0013-env-increment-redund-flag-on-read-fail.patch \
+	file://0014-env-Fix-invalid-env-handling-in-env_init.patch \
+	file://0015-env-Fix-prio-on-bad-CRC-case-with-ENV_APPEND-enabled.patch \
+	file://0016-env-Invert-gd-env_valid-for-env_mmc_save.patch \
+	file://0017-imx8m-soc.c-Use-arch-specific-env_get_location.patch \
 "
 
 FILESEXTRAPATHS_prepend_imx8mpevk := "${THISDIR}/u-boot-imx/imx8mpevk:"

--- a/recipes-bsp/u-boot/u-boot-imx_iris.inc
+++ b/recipes-bsp/u-boot/u-boot-imx_iris.inc
@@ -64,4 +64,7 @@ SRC_URI_append_imx8mp-irma6r2 = "\
 	file://0019-imx8mp-irma6r2-defconfig-Use-redundand-env-support.patch \
 	file://0020-imx8mp-irma6r2-Implementing-bootcount_limit-for-irma6r2.patch \
 	file://0021-imx8mp_irma6r2.h-Introduce-netfitboot-command.patch \
+	file://0022-imx8mp-irma6r2-Add-CONFIG_ENV_FLAGS_LIST_STATIC.patch \
+	file://0023-imx8mp-irma6r2-Add-reset-after-bootcmd.patch \
+	file://0024-imx8mp_irma6r2_defconfig-Configure-writeable-list-su.patch \
 "

--- a/recipes-bsp/u-boot/u-boot-imx_iris.inc
+++ b/recipes-bsp/u-boot/u-boot-imx_iris.inc
@@ -36,6 +36,9 @@ SRC_URI_append_imx8mpevk = "\
 	file://0008-imx8mp-evk-Resorting-imx8mp_evk_defconfig.patch \
 	file://0009-imx8mp-evk-Implementing-bootcount_limit.patch \
 	file://0010-imx8mp_evk.h-Introduce-netfitboot-command.patch \
+	file://0011-imx8mpevk-Add-reset-after-bootcmd.patch \
+	file://0012-imx8mp-evk-Add-CONFIG_ENV_FLAGS_LIST_STATIC.patch \
+	file://0013-imx8mp_evk_defconfig-Configure-writeable-list-suppor.patch \
 "
 
 FILESEXTRAPATHS_prepend_imx8mp-irma6r2 := "${THISDIR}/u-boot-imx/imx8mp-irma6r2:"


### PR DESCRIPTION
With this feature, the u-boot env's to be imported by the EMMC are limited to a few.

```
#define CONFIG_ENV_FLAGS_LIST_STATIC \
       "upgrade_available:dw," \
       "bootcount:dw," \
       "ustate:dw," \
       "firmware:dw"
```

First the default env's are loaded from the u-boot (nowhere) and then the env's from the EMMC.
The special feature is that only the env's from the writelist are overwritten, all other env's from the EMMC are ignored when importing.


Tested with irma6-maintenance-uuu on the imx8mp-evk and imx8mp-irma6r2!

**Test**
```
1. Check bootlog Part 1:

Loading Environment from nowhere... OK                                                                                                                   
Loading Environment from MMC... *** Warning - bad CRC, using default environment  <-- ok, there are no env on emmc on first boot

2. Check printenv
u-boot=> printenv
firmware=0
upgrade_available=0
ustate=0
ver=U-Boot 2020.04-00002-gc4497e2c54 (Jun 14 2022 - 21:04:58 +0200)  <--- NEW !!!

3. Test alternating saveenv works
u-boot=> saveenv                                                                                                                                         
Saving Environment to MMC... Writing to MMC(2)... OK                                                                                                     
u-boot=> saveenv                                                                                                                                         
Saving Environment to MMC... Writing to redundant MMC(2)... OK                                                                                           
u-boot=> saveenv                                                                                                                                         
Saving Environment to MMC... Writing to MMC(2)... OK                                                                                                     
u-boot=> saveenv                                                                                                                                         
Saving Environment to MMC... Writing to redundant MMC(2)... OK

4. Test ENV_WRITEABLE_LIST works
u-boot=> setenv ustate 1
u-boot=> setenv my_var test_str
u-boot=> setenv firmware 3
u-boot=> saveenv
Saving Environment to MMC... Writing to MMC(2)... OK

u-boot=> printenv                                                                                                                                                                                                                                                                     
firmware=3                                                                                                                                                                                                                                                              
my_var=test_str                                                                                                                                                                                                                                                                          
ustate=1                                                                                                                                                 

u-boot=> reset 
u-boot=> printenv                                                                                                                                       
firmware=3                                                                                                                                               
[..]    <-- "my_var" is not imported, because it is not part of the ENV_WRITEABLE_LIST
ustate=1

5. Retry 4. with redunand env slot
-> "Saving Environment to MMC... Writing to redundant MMC(2)... OK"

6. Bootlog überprüfen Teil 2:

Loading Environment from nowhere... OK
Loading Environment from MMC... OK      <-- ok, after saveenv is called there are valid env's on EMMC

7. Test interaction with Linux (fw_printenv/fw_setenv):
root@imx8mpevk:~# fw_printenv
firmware=3
my_var=test_str  <--!!! Yes, my_var still exists, when reading with fw_printenv. However, it is not imported in u-boot.
upgrade_available=0
ustate=1

root@imx8mpevk:~# fw_setenv firmware 4                                                                                                                                                                   
root@imx8mpevk:~# fw_setenv ustate 2

root@imx8mpevk:~# fw_printenv
firmware=4
my_var=test_str
ustate=2

root@imx8mpevk:~#  reboot

u-boot=> printenv
firmware=4
upgrade_available=0
ustate=2

9. Use default env
u-boot=> env default -a
u-boot=> saveenv
u-boot=> reset
u-boot=> printenv
firmware=0
upgrade_available=0
ustate=0

```