### PR TITLE
[RDPHOEN-1192] caam swupdate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [APR's Version Numbering](https://apr.apache.org/ver
 - [RDPHOEN-1154] Implementing bootcount_limit for imx8mp-evk and imx8mp-irma6r2
 - [RDPHOEN-1165]: Add netboot fitimage for R2
 - [RDPHOEN-256]: Add linux watchdog feature
+- [RDPHOEN-1192]: Add encrypted storage swupdate support
 
 
 ### Changed

--- a/recipes-bsp/irma6-uuu/files/flashall_imx8mp.uuu
+++ b/recipes-bsp/irma6-uuu/files/flashall_imx8mp.uuu
@@ -69,16 +69,13 @@ FBK: ucmd vgmknodes
 
 # Create fat data partition (keystore)
 FBK: ucmd mkfs.vfat /dev/mapper/irma6lvm-keystore
-FBK: ucmd mkdir -p /mnt/keystore
 FBK: ucmd mount -t vfat /dev/mapper/irma6lvm-keystore /mnt/keystore
 
 # Generate black key blobs
-FBK: ucmd ln -s /mnt/keystore /data
 FBK: ucmd caam-keygen create volumeKey ccm -s 32
-FBK: ucmd rm /data
 
 # Setup encrypted partitions
-FBK: ucmd cat /mnt/keystore/caam/volumeKey | keyctl padd logon logkey: @us
+FBK: ucmd keyctl padd logon logkey: @us < /mnt/keystore/caam/volumeKey
 FBK: ucmd dmsetup -v create decrypted-irma6lvm-rootfs_a --table "0 $(blockdev --getsz /dev/mapper/irma6lvm-rootfs_a) crypt capi:tk(cbc(aes))-plain :64:logon:logkey: 0 /dev/mapper/irma6lvm-rootfs_a 0 1 sector_size:4096"
 FBK: ucmd dmsetup -v create decrypted-irma6lvm-rootfs_b --table "0 $(blockdev --getsz /dev/mapper/irma6lvm-rootfs_b) crypt capi:tk(cbc(aes))-plain :64:logon:logkey: 0 /dev/mapper/irma6lvm-rootfs_b 0 1 sector_size:4096"
 FBK: ucmd dmsetup -v create decrypted-irma6lvm-userdata --table "0 $(blockdev --getsz /dev/mapper/irma6lvm-userdata) crypt capi:tk(cbc(aes))-plain :64:logon:logkey: 0 /dev/mapper/irma6lvm-userdata 0 1 sector_size:4096"

--- a/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-core/base-files/base-files_%.bbappend
@@ -2,5 +2,5 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 SRC_URI += "file://fstab"
 
-# Create /mnt/iris so the fstab can use it as mountpoint
-dirs755_append_mx8mp = " /mnt/iris"
+# Create /mnt/ folders so the fstab can use it as mountpoint
+dirs755:append:mx8mp = " /mnt/keystore /mnt/iris"

--- a/recipes-security/smw/keyctl-caam_git.bb
+++ b/recipes-security/smw/keyctl-caam_git.bb
@@ -16,6 +16,9 @@ S = "${WORKDIR}/git"
 
 TARGET_CC_ARCH += "${LDFLAGS}"
 
+# Adjust keyblob location - this is fixed and cannot be changed during runtime
+EXTRA_OEMAKE = "KEYBLOB_LOCATION=/mnt/keystore/caam/"
+
 do_install () {
     oe_runmake DESTDIR=${D} install
 }

--- a/recipes-support/irma6-swuimage/files/pre_post_inst.sh
+++ b/recipes-support/irma6-swuimage/files/pre_post_inst.sh
@@ -24,28 +24,47 @@ parse_cmdline() {
 	echo "Update firmware${FIRMWARE_SUFFIX}"
 }
 
-get_device_names() {
+set_device_names() {
+	KEYSTORE_DEV="/dev/mapper/irma6lvm-keystore"
+	KEYSTORE="/mnt/keystore"
+
+	ROOT_DEV="/dev/mapper/irma6lvm-rootfs${FIRMWARE_SUFFIX}"
+	ROOT_HASH_DEV="/dev/mapper/irma6lvm-rootfs${FIRMWARE_SUFFIX}_hash"
+	ROOT_HASH="${KEYSTORE}/rootfs${FIRMWARE_SUFFIX}_roothash"
+
+	VERITY_NAME="verity-rootfs${FIRMWARE_SUFFIX}"
+	VERITY_DEV="/dev/mapper/${VERITY_NAME}"
+
+	DECRYPT_NAME="decrypted-irma6lvm-rootfs${FIRMWARE_SUFFIX}"
+	DECRYPT_ROOT_DEV="/dev/mapper/${DECRYPT_NAME}"
+}
+
+unlock_device() {
+	# Add Black key to keyring
+	caam-keygen import $KEYSTORE/caam/volumeKey.bb importKey
+	keyctl padd logon logkey: @us < $KEYSTORE/caam/importKey
+
+	# TODO: Error handling when alternative boot volume is corrupted
+	dmsetup create ${DECRYPT_NAME} --table "0 $(blockdev --getsz ${ROOT_DEV}) \
+		crypt capi:tk(cbc(aes))-plain :64:logon:logkey: 0 ${ROOT_DEV} 0 1 sector_size:4096" || exit 1
+}
+
+lock_device() {
+	dmsetup remove ${DECRYPT_NAME}
+}
+
+get_bootdev_name() {
 	EMMC_DEV="/dev/mmcblk2"
-	SWU_KERNEL_DEV=$(sfdisk -J $EMMC_DEV | jq 'first(.partitiontable.partitions[] | select ((.name!=null) and (.name=="linuxboot'${FIRMWARE_SUFFIX}'")) | .node)' -r)
-	if [ -z "$SWU_KERNEL_DEV" ]; then
-		echo "Could not locate boot partition for firmware${FIRMWARE_SUFFIX}"; exit 10;
-	fi
-
-	SWU_ROOT_DEV="/dev/mapper/irma6lvm-rootfs${FIRMWARE_SUFFIX}"
-	if [ -z "$SWU_ROOT_DEV" ]; then
-		echo "Could not locate $SWU_ROOT_DEV"; exit 10;
-	fi
-
-	SWU_ROOT_HASH="/dev/mapper/irma6lvm-rootfs${FIRMWARE_SUFFIX}_hash"
-	if [ -z "$SWU_ROOT_HASH" ]; then
-		echo "Could not locate $SWU_ROOT_HASH"; exit 10;
+	KERNEL_DEV=$(sfdisk -J $EMMC_DEV | jq 'first(.partitiontable.partitions[] | select ((.name!=null) and (.name=="linuxboot'${FIRMWARE_SUFFIX}'")) | .node)' -r)
+	if ! [ -b "$KERNEL_DEV" ]; then
+		echo "Could not locate boot partition for firmware${FIRMWARE_SUFFIX}"; exit 1;
 	fi
 }
 
 create_symlinks() {
-	ln -sf "$SWU_KERNEL_DEV" /dev/swu_kernel
-	ln -sf "$SWU_ROOT_DEV" /dev/swu_rootfs
-	ln -sf "$SWU_ROOT_HASH" /dev/swu_rootfs_hash
+	ln -sf "$KERNEL_DEV" /dev/swu_kernel || exit 1
+	ln -sf "$DECRYPT_ROOT_DEV" /dev/swu_rootfs || exit 1
+	ln -sf "$ROOT_HASH_DEV" /dev/swu_rootfs_hash || exit 1
 }
 
 remove_symlinks() {
@@ -54,30 +73,38 @@ remove_symlinks() {
 	rm /dev/swu_rootfs_hash
 }
 
-write_root_hash() {
-	HASH_DEV="/dev/mapper/irma6lvm-keystore"
-	HASH_MNT="/tmp/keystore"
-	ROOTHASH="/tmp/keystore/rootfs${FIRMWARE_SUFFIX}_roothash"
+mount_keystore() {
+	mount -t vfat ${KEYSTORE_DEV} ${KEYSTORE} || exit 1
+}
 
+umount_keystore() {
+	umount ${KEYSTORE}
+}
+
+write_root_hash() {
 	# TODO: Unsafe! Store roothash in a secure manner!
-	mkdir -p ${HASH_MNT} || exit 1
-	mount -t vfat ${HASH_DEV} ${HASH_MNT} || exit 1
-	veritysetup format ${SWU_ROOT_DEV} ${SWU_ROOT_HASH} | grep "Root hash:" | grep -Eo "[0-9a-f]+$" > ${ROOTHASH} || exit 1
-	umount ${HASH_MNT} || exit 1
+	veritysetup format ${DECRYPT_ROOT_DEV} ${ROOT_HASH_DEV} | grep "Root hash:" | grep -Eo "[0-9a-f]+$" > ${ROOT_HASH} || exit 1
+	
 }
 
 if [ "$1" = "preinst" ]; then
 	cmds_exist	
 	parse_cmdline
-	get_device_names
+	set_device_names
+	mount_keystore
+	unlock_device
+	get_bootdev_name
 	create_symlinks
 	exit 0
 fi
 
 if [ "$1" = "postinst" ]; then
 	parse_cmdline
-	get_device_names
+	set_device_names
+	get_bootdev_name
 	write_root_hash
+	lock_device
+	umount_keystore
 	remove_symlinks
 	exit 0
 fi


### PR DESCRIPTION
## Unlocks encrypted A/B volume update

### Extended test: [PR93](https://github.com/iris-GmbH/meta-iris-base/pull/93)
### Quick test A -> B:
1. Checkout this branch & build the swu file (cannot be built in Jenkins for now):
`$ bitbake mc:imx8mp-evk:irma6-maintenance-swuimage`
2. Boot device on path A (default) 
3. Copy the swu file to target, maintenance allows scp:
`# cd /mnt/iris`
`# scp user@ipaddr:/path/to/irma6-maintenance-swuimage-imx8mpevk-20220616101257.swu .`
4. Start swupdate:
`# swupdate -v -i irma6-maintenance-swuimage-imx8mpevk-20220616101257.swu`
5. Reboot 
6. Confirm that path B is used and works for booting:
`[    4.103574] Run /init as init process`
`Mount pseudo fs`
`  8 logical volume(s) in volume group "irma6lvm" now active`
`Initramfs Bootstrap...`
`Kernel cmdline: console=ttymxc1,115200 root=/dev/mmcblk2p-22 rootwait rw firmware_b`
`Select firmware_b`
`Root mnt   : /mnt`
`Root device: /dev/mapper/irma6lvm-rootfs_b`
`Crypt device: /dev/mapper/decrypted-irma6lvm-rootfs_b`
`Verity device: /dev/mapper/verity-rootfs_b`
`193820451`
`Unlocking encrypted device: /dev/mapper/irma6lvm-rootfs_b`
`Unlocking encrypted device: /dev/mapper/irma6lvm-userdata`
`Opening verity device: /dev/mapper/decrypted-irma6lvm-rootfs_b`
