### PR TITLE
Feature/migl/rdphoen 1182 swupdate wwwdir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ and this project adheres to [APR's Version Numbering](https://apr.apache.org/ver
 - [RDPHOEN-1165]: Add netboot fitimage for R2
 - [RDPHOEN-256]: Add linux watchdog feature
 - [RDPHOEN-1192]: Add encrypted storage swupdate support
+- [RDPHOEN-1182]: Configure swupdate's fallback webserver mongoose and add swupdate's www root
+- [RDPHOEN-1182]: Move nginx content to meta-iris to avoid multiple nginx_%.bbappend's
+- [RDPHOEN-1182]: Enable read-only-rootfs tweaks and use default's fstab mount points
 
 
 ### Changed

--- a/conf/distro/poky-iris.conf
+++ b/conf/distro/poky-iris.conf
@@ -34,5 +34,7 @@ SIGN_CERT ?= "${HAB_DIR}/crts/IMG1_1_sha256_secp521r1_v3_usr_crt.pem"
 CRYPTO_HW_ACCEL ?= "CAAM"
 BBMASK += "meta-secure-imx/recipes-bsp/u-boot/u-boot_%.bbappend"
 
+IMAGE_FEATURES += "read-only-rootfs"
+
 # FIXME [RDPHOEN-1177]: This needs to be disabled for security reasons in Rel2
 IMAGE_FEATURES += "debug-tweaks"

--- a/conf/machine/include/sc57x.inc
+++ b/conf/machine/include/sc57x.inc
@@ -40,3 +40,5 @@ BOARD ?= "sc573-gen6"
 # ldconfig is used to rebuild the /etc/ld.so.cache when new libraries are introduced during runtime
 # this is not needed and /etc/ld.so.cache is already populated by Yocto, disabling this saves ~250kB
 DISTRO_FEATURES_remove += "ldconfig"
+
+IMAGE_FEATURES_remove += "read-only-rootfs"

--- a/recipes-core/base-files/base-files/mx8mp/fstab
+++ b/recipes-core/base-files/base-files/mx8mp/fstab
@@ -1,8 +1,8 @@
 /dev/root            /                    auto       defaults              1  1
 proc                 /proc                proc       defaults              0  0
-devpts               /dev/pts             devpts     mode=0620,gid=5       0  0
-tmpfs                /tmp                 tmpfs      defaults              0  0
-tmpfs                /var/run             tmpfs      defaults              0  0
+devpts               /dev/pts             devpts     mode=0620,ptmxmode=0666,gid=5      0  0
+tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,strictatime 0  0
+tmpfs                /var/volatile        tmpfs      defaults              0  0
 /dev/mapper/decrypted-irma6lvm-userdata /mnt/iris ext4 defaults            0  0
 
 # bind mount directories for r/w access

--- a/recipes-core/dropbear/dropbear_%.bbappend
+++ b/recipes-core/dropbear/dropbear_%.bbappend
@@ -1,1 +1,1 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+FILESEXTRAPATHS_prepend_sc57x := "${THISDIR}/${PN}:"

--- a/recipes-core/images/irma6-base.bb
+++ b/recipes-core/images/irma6-base.bb
@@ -52,7 +52,7 @@ IMAGE_INSTALL_append = " \
 "
 
 # Include swupdate in image if swupdate is part of the update procedure
-IMAGE_INSTALL_append = " ${@bb.utils.contains('UPDATE_PROCEDURE', 'swupdate', 'swupdate', '', d)}"
+IMAGE_INSTALL_append = " ${@bb.utils.contains('UPDATE_PROCEDURE', 'swupdate', 'swupdate swupdate-www', '', d)}"
 
 # this cannot be done directly in the os-release recipe, due to yocto's buttom-up approach
 # os-release does not know how the final image will be named, as the IMAGE_NAME variable is out of scope

--- a/recipes-httpd/nginx/nginx_%.bbappend
+++ b/recipes-httpd/nginx/nginx_%.bbappend
@@ -1,1 +1,0 @@
-PACKAGECONFIG_append = " http-auth-request"

--- a/recipes-support/swupdate/swupdate/defconfig
+++ b/recipes-support/swupdate/swupdate/defconfig
@@ -1,11 +1,10 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Swupdate Configuration
+# SWUpdate Configuration
 #
-CONFIG_HAVE_DOT_CONFIG=y
 
 #
-# Swupdate Settings
+# SWUpdate Settings
 #
 
 #
@@ -13,6 +12,7 @@ CONFIG_HAVE_DOT_CONFIG=y
 #
 # CONFIG_CURL is not set
 # CONFIG_CURL_SSL is not set
+# CONFIG_DISKFORMAT is not set
 # CONFIG_SYSTEMD is not set
 CONFIG_DEFAULT_CONFIG_FILE="/etc/swupdate.cfg"
 CONFIG_SCRIPTS=y
@@ -25,8 +25,7 @@ CONFIG_SW_VERSIONS_FILE="/etc/sw-versions"
 #
 CONFIG_SOCKET_CTRL_PATH=""
 CONFIG_SOCKET_PROGRESS_PATH=""
-CONFIG_SOCKET_REMOTE_HANDLER_DIRECTORY="/tmp/"
-CONFIG_MTD=y
+# CONFIG_MTD is not set
 CONFIG_LUA=y
 CONFIG_LUAPKG="lua"
 # CONFIG_FEATURE_SYSLOG is not set
@@ -44,51 +43,84 @@ CONFIG_EXTRA_LDLIBS=""
 # CONFIG_DEBUG is not set
 # CONFIG_WERROR is not set
 # CONFIG_NOCLEANUP is not set
+
+#
+# Bootloader support
+#
+
+#
+# Bootloader Interfaces
+#
+# CONFIG_BOOTLOADER_NONE is not set
 # CONFIG_BOOTLOADER_EBG is not set
 CONFIG_UBOOT=y
-# CONFIG_BOOTLOADER_NONE is not set
-# CONFIG_BOOTLOADER_GRUB is not set
 CONFIG_UBOOT_FWENV="/etc/fw_env.config"
+CONFIG_UBOOT_DEFAULTENV="/etc/u-boot-initial-env"
+# CONFIG_BOOTLOADER_GRUB is not set
+CONFIG_BOOTLOADER_DEFAULT_UBOOT=y
 # CONFIG_UPDATE_STATE_CHOICE_NONE is not set
 CONFIG_UPDATE_STATE_CHOICE_BOOTLOADER=y
 CONFIG_UPDATE_STATE_BOOTLOADER="ustate"
-CONFIG_UBOOT_DEFAULTENV="/etc/u-boot-initial-env"
+
+#
+# Interfaces
+#
+# CONFIG_DOWNLOAD is not set
+# CONFIG_SURICATTA is not set
+CONFIG_WEBSERVER=y
+CONFIG_MONGOOSE=y
+# CONFIG_MONGOOSEIPV6 is not set
+# CONFIG_MONGOOSESSL is not set
+
+#
+# Security
+#
 # CONFIG_SSL_IMPL_NONE is not set
 CONFIG_SSL_IMPL_OPENSSL=y
+# CONFIG_SSL_IMPL_WOLFSSL is not set
 # CONFIG_SSL_IMPL_MBEDTLS is not set
-# CONFIG_DOWNLOAD is not set
 CONFIG_HASH_VERIFY=y
 # CONFIG_SIGNED_IMAGES is not set
 # CONFIG_ENCRYPTED_IMAGES is not set
-# CONFIG_SURICATTA is not set
-# CONFIG_WEBSERVER is not set
+
+#
+# Compressors (zlib always on)
+#
 CONFIG_GUNZIP=y
 # CONFIG_ZSTD is not set
+
+#
+# Parsers
+#
 
 #
 # Parser Features
 #
 CONFIG_LIBCONFIG=y
 CONFIG_PARSERROOT=""
-# CONFIG_JSON is not set
+CONFIG_JSON=y
 # CONFIG_LUAEXTERNAL is not set
 # CONFIG_SETSWDESCRIPTION is not set
 
 #
+# Handlers
+#
+
+#
 # Image Handlers
 #
-# CONFIG_UBIVOL is not set
-CONFIG_CFI=y
-# CONFIG_CFIHAMMING1 is not set
+# CONFIG_ARCHIVE is not set
+CONFIG_BOOTLOADERHANDLER=y
+# CONFIG_DELTA is not set
 # CONFIG_DISKPART is not set
+# CONFIG_DISKFORMAT_HANDLER is not set
+CONFIG_LUASCRIPTHANDLER=y
+# CONFIG_HANDLER_IN_LUA is not set
 CONFIG_RAW=y
 # CONFIG_RDIFFHANDLER is not set
-CONFIG_LUASCRIPTHANDLER=y
-CONFIG_SHELLSCRIPTHANDLER=y
-# CONFIG_HANDLER_IN_LUA is not set
-# CONFIG_ARCHIVE is not set
+CONFIG_READBACKHANDLER=y
 # CONFIG_REMOTE_HANDLER is not set
+CONFIG_SHELLSCRIPTHANDLER=y
 # CONFIG_SWUFORWARDER_HANDLER is not set
-CONFIG_BOOTLOADERHANDLER=y
-# CONFIG_SSBLSWITCH is not set
 # CONFIG_UCFWHANDLER is not set
+# CONFIG_UNIQUEUUID is not set

--- a/recipes-support/swupdate/swupdate/swupdate_default_args
+++ b/recipes-support/swupdate/swupdate/swupdate_default_args
@@ -1,3 +1,8 @@
 # -v, --verbose:          be verbose, set maximum loglevel
 # -p, --postupdate:       execute post-update command
 SWUPDATE_ARGS="-v -p 'reboot'"
+
+# -p, --port <port>              : server port number  (default: 8080)
+# -r, --document-root <path>     : path to document root directory (default: .)
+# -t, --timeout                  : timeout to check if connection is lost (default: check disabled)
+SWUPDATE_WEBSERVER_ARGS="-r /var/www/swupdate -p 8080"

--- a/recipes-support/swupdate/swupdate_%.bbappend
+++ b/recipes-support/swupdate/swupdate_%.bbappend
@@ -3,6 +3,8 @@
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
+wwwdir = "/var/www/swupdate"
+
 # Put reset script right after counting application
 RESET_SCRIPT="reset_upgrade_available.sh"
 RESET_SCRIPT_SYM="S92reset_upgrade_available"


### PR DESCRIPTION
Configure swupdate's fallback webserver mongoose and add swupdate's www root

**Jenkins**

- R1: [#1306](http://jenkinsmaster.irisgmbh.local:8080/job/RD-V/job/IRMA6/view/Irma6_Yocto_Build_Firmware_Pipeline.feature/)

**Build**

```
$ bitbake mc:imx8mp-evk:irma6-maintenance-uuu
$ bitbake mc:imx8mp-evk:irma6-maintenance-swuimage
```

**Test R2**

```
$ cd iris-kas/build/tmp/deploy/images/imx8mpevk/irma6-maintenance-uuu
$ uuu flashall.uuu

# Target
$ cat /proc/cmdline
root@imx8mpevk:~# cat /proc/cmdline                                            
console=ttymxc1,115200 root=/dev/mmcblk2p2 rootwait rw linuxboot_a

# 1. Test: Host: Update via swupdate:
1. http://<I6R2_IP>/swupdate/
2. Drag&Drop swu image
3. Check log for sensor update, reboot & firmware toggle
root@imx8mpevk:~# cat /proc/cmdline                                            
console=ttymxc1,115200 root=/dev/mmcblk2p2 rootwait rw linuxboot_b

# 2. Test: Host: Update via irma6 website:
1. Make sure count_von_count is running
2. http://<I6R2_IP>/ -> Select update subpage
3. Go to Update and select swu image
4. Reboot manually. POST_UPDATE ipc msg is not implemented in count_von_count yet.
5. Check log for sensor update, reboot & firmware toggle
```
