### PR TITLE
[RDPHOEN-1060] Add kernel driver for eth0 ADIn1200 PHY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [APR's Version Numbering](https://apr.apache.org/ver
 - [RDPHOEN-1182]: Configure swupdate's fallback webserver mongoose and add swupdate's www root
 - [RDPHOEN-1182]: Move nginx content to meta-iris to avoid multiple nginx_%.bbappend's
 - [RDPHOEN-1182]: Enable read-only-rootfs tweaks and use default's fstab mount points
+- [RDPHOEN-1060] Add kernel driver for eth0 ADIn1200 PHY
+
 
 
 ### Changed

--- a/recipes-kernel/linux/linux-fslc-iris.inc
+++ b/recipes-kernel/linux/linux-fslc-iris.inc
@@ -39,7 +39,7 @@ SRC_URI += " \
     file://0031-tc358746.c-Reset-when-changing-format.patch \
     file://0032-imx8mp-irma6r2.dts-Change-memory-range-for-dsp.patch \
     file://0033-imx8mp-irma6r2.dts-Add-csi_mclk-to-pinctrl.patch \
-"
+    file://0034-imx8mp-irma6r2.dts-Add-kernel-driver-for-eth0-ADIn1200-PHY.patch"
 
 KERNEL_DEFCONFIG_imx8mpevk = "imx8mp-evk-r2_defconfig"
 KERNEL_DEFCONFIG_imx8mp-irma6r2 = "imx8mp_irma6r2_defconfig"

--- a/recipes-kernel/linux/linux-fslc-iris/0034-imx8mp-irma6r2.dts-Add-kernel-driver-for-eth0-ADIn1200-PHY.patch
+++ b/recipes-kernel/linux/linux-fslc-iris/0034-imx8mp-irma6r2.dts-Add-kernel-driver-for-eth0-ADIn1200-PHY.patch
@@ -1,0 +1,73 @@
+From fcc6014c083f20d0487e634262a78029c9d6e231 Mon Sep 17 00:00:00 2001
+From: "Jan.Hannig" <jan.hannig@irisgmbh.de>
+Date: Tue, 28 Jun 2022 10:16:44 +0200
+Subject: [PATCH] [RDPHOEN-1060] Add kernel driver for eth0 ADIn1200 PHY
+
+Replace 125 MHz clock for RGMII by 50 MHz clk for RMII.
+
+Signed-off-by: Jan.Hannig <jan.hannig@irisgmbh.de>
+---
+ .../boot/dts/freescale/imx8mp-irma6r2.dts     | 40 +++++++++++++++++++
+ 1 file changed, 40 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/freescale/imx8mp-irma6r2.dts b/arch/arm64/boot/dts/freescale/imx8mp-irma6r2.dts
+index fc19e92c0757..70f2091099dc 100644
+--- a/arch/arm64/boot/dts/freescale/imx8mp-irma6r2.dts
++++ b/arch/arm64/boot/dts/freescale/imx8mp-irma6r2.dts
+@@ -129,6 +129,30 @@
+ 	status = "okay";
+ };
+ 
++&eqos {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_eqos>;
++	phy-mode = "rmii";
++	phy-handle = <&ethphy0>;
++	status = "okay";
++	assigned-clock-parents = <&clk IMX8MP_SYS_PLL1_266M>,
++							 <&clk IMX8MP_SYS_PLL2_100M>,
++							 <&clk IMX8MP_SYS_PLL2_50M>;
++	assigned-clock-rates = <0>, <100000000>, <50000000>;
++
++	mdio {
++		compatible = "snps,dwmac-mdio";
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		ethphy0: ethernet-phy@1 {
++			compatible = "ethernet-phy-ieee802.3-c22";
++			reg = <1>;
++			eee-broken-1000t;
++		};
++	};
++};
++
+ &i2c1 {
+ 	clock-frequency = <384000>;
+ 	pinctrl-names = "default";
+@@ -498,6 +522,22 @@
+ 		>;
+ 	};
+ 
++	pinctrl_eqos: eqosgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_ENET_MDC__ENET_QOS_MDC	0x3
++			MX8MP_IOMUXC_ENET_MDIO__ENET_QOS_MDIO	0x3
++			MX8MP_IOMUXC_ENET_RD0__ENET_QOS_RGMII_RD0	0x91        /* ETH-RX0 AG29 */
++			MX8MP_IOMUXC_ENET_RD1__ENET_QOS_RGMII_RD1	0x91        /* ETH-RX1 AG28 */
++			MX8MP_IOMUXC_ENET_RX_CTL__ENET_QOS_RGMII_RX_CTL	0x91    /* ETH-DV  AE28 */
++			MX8MP_IOMUXC_ENET_TD0__ENET_QOS_RGMII_TD0		0x1f    /* ETH-TX0 AC25 */
++			MX8MP_IOMUXC_ENET_TD1__ENET_QOS_RGMII_TD1		0x1f    /* ETH-TX1 AE26 */
++			MX8MP_IOMUXC_ENET_TD2__CCM_ENET_QOS_CLOCK_GENERATE_REF_CLK 0x4000001f /* ETH-50 AF26 */
++			MX8MP_IOMUXC_ENET_TX_CTL__ENET_QOS_RGMII_TX_CTL	0x1f    /* ETH-TXEN  AF24 */
++			/*MX8MP_IOMUXC_ENET_TXC__CCM_ENET_QOS_CLOCK_GENERATE_TX_CLK	0x1f*/
++			MX8MP_IOMUXC_SAI1_TXD2__GPIO4_IO14		0x19            /* ETH-RST AH11 */
++		>;
++	};
++
+ 	pinctrl_gpio_led: gpioledgrp {
+ 		fsl,pins = <
+ 			MX8MP_IOMUXC_SAI1_RXD3__GPIO4_IO05	0x19
+-- 
+2.20.1
+


### PR DESCRIPTION
imx8mp-irma6r2.dts: Replace 125 MHz clock for RGMII by 50 MHz clk for RMII.