### PR TITLE
[RDPHOEN-1060] Patch uboot-imx: Generic EQOS driver usable for RMII

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [APR's Version Numbering](https://apr.apache.org/ver
 - [RDPHOEN-1182]: Move nginx content to meta-iris to avoid multiple nginx_%.bbappend's
 - [RDPHOEN-1182]: Enable read-only-rootfs tweaks and use default's fstab mount points
 - [RDPHOEN-1060] Add kernel driver for eth0 ADIn1200 PHY
+- [RDPHOEN-1060]: Fix eqos driver in uboot to get ethernet working on release 2 hardware
 
 
 

--- a/recipes-bsp/u-boot/u-boot-imx/imx8mp-irma6r2/0025-imx8mp_irma6r2-Generic-EQOS-driver-dwc_eth_qos.c-usable-for-RMII.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/imx8mp-irma6r2/0025-imx8mp_irma6r2-Generic-EQOS-driver-dwc_eth_qos.c-usable-for-RMII.patch
@@ -1,0 +1,123 @@
+From 289fdc82ac7faaa8e7577e3b0d23a5d20c1e1bc3 Mon Sep 17 00:00:00 2001
+From: "Jan.Hannig" <jan.hannig@irisgmbh.de>
+Date: Thu, 30 Jun 2022 18:02:40 +0200
+Subject: [PATCH] [RDPHOEN-1060] Generic EQOS driver dwc_eth_qos.c usable for
+ RMII
+
+imx8mp_irma6r2.h:
+Introduced CONFIG_RMII;
+changed CONFIG_FEC_XCV_TYPE to RMII
+(although FEC isn't implemented actually)
+dwc_eth_qos.c:
+Implemented workarounds RMII interface support
+as it doesn't seem to be supported correctly in generic EQOS driver.
+imx8mp-irma6r2.dts:
+Added pin comments according to hardware schematic.
+
+Signed-off-by: Jan.Hannig <jan.hannig@irisgmbh.de>
+---
+ arch/arm/dts/imx8mp-irma6r2.dts  | 16 ++++++++--------
+ drivers/net/dwc_eth_qos.c        | 32 ++++++++++++++++++++++++++++++++
+ include/configs/imx8mp_irma6r2.h |  3 ++-
+ 3 files changed, 42 insertions(+), 9 deletions(-)
+
+diff --git a/arch/arm/dts/imx8mp-irma6r2.dts b/arch/arm/dts/imx8mp-irma6r2.dts
+index 0afa503d80..ade7adadd0 100644
+--- a/arch/arm/dts/imx8mp-irma6r2.dts
++++ b/arch/arm/dts/imx8mp-irma6r2.dts
+@@ -383,14 +383,14 @@
+ 		fsl,pins = <
+ 			MX8MP_IOMUXC_ENET_MDC__ENET_QOS_MDC	0x3
+ 			MX8MP_IOMUXC_ENET_MDIO__ENET_QOS_MDIO	0x3
+-			MX8MP_IOMUXC_ENET_RD0__ENET_QOS_RGMII_RD0	0x91
+-			MX8MP_IOMUXC_ENET_RD1__ENET_QOS_RGMII_RD1	0x91
+-			MX8MP_IOMUXC_ENET_RX_CTL__ENET_QOS_RGMII_RX_CTL	0x91
+-			MX8MP_IOMUXC_ENET_TD0__ENET_QOS_RGMII_TD0		0x1f
+-			MX8MP_IOMUXC_ENET_TD1__ENET_QOS_RGMII_TD1		0x1f
+-			MX8MP_IOMUXC_ENET_TD2__CCM_ENET_QOS_CLOCK_GENERATE_REF_CLK 0x4000001f
+-			MX8MP_IOMUXC_ENET_TX_CTL__ENET_QOS_RGMII_TX_CTL	0x1f
+-			MX8MP_IOMUXC_SAI1_TXD2__GPIO4_IO14		0x19
++			MX8MP_IOMUXC_ENET_RD0__ENET_QOS_RGMII_RD0	0x91        /* ETH-RX0 AG29 */
++			MX8MP_IOMUXC_ENET_RD1__ENET_QOS_RGMII_RD1	0x91        /* ETH-RX1 AG28 */
++			MX8MP_IOMUXC_ENET_RX_CTL__ENET_QOS_RGMII_RX_CTL	0x91    /* ETH-DV  AE28 */
++			MX8MP_IOMUXC_ENET_TD0__ENET_QOS_RGMII_TD0		0x1f    /* ETH-TX0 AC25 */
++			MX8MP_IOMUXC_ENET_TD1__ENET_QOS_RGMII_TD1		0x1f    /* ETH-TX1 AE26 */
++			MX8MP_IOMUXC_ENET_TD2__CCM_ENET_QOS_CLOCK_GENERATE_REF_CLK 0x4000001f /* ETH-50 AF26 */
++			MX8MP_IOMUXC_ENET_TX_CTL__ENET_QOS_RGMII_TX_CTL	0x1f    /* ETH-TXEN  AF24 */
++			MX8MP_IOMUXC_SAI1_TXD2__GPIO4_IO14		0x19            /* ETH-RST AH11 */
+ 		>;
+ 	};
+ 
+diff --git a/drivers/net/dwc_eth_qos.c b/drivers/net/dwc_eth_qos.c
+index d8c21be5eb..c70b764b91 100644
+--- a/drivers/net/dwc_eth_qos.c
++++ b/drivers/net/dwc_eth_qos.c
+@@ -1037,12 +1037,20 @@ static int eqos_set_tx_clk_speed_imx(struct udevice *dev)
+ 		return -EINVAL;
+ 	}
+ 
++#ifdef CONFIG_RMII
++/* The RMII interface isn't implemented correctly in this generic driver, only RGMII is served here (see code in #else path). 
++The clock rate functions in the #else path are called to adapt the interface clock according to the speed rate of ethernet PHY.
++As the interface clock frequency for the RMII interface is constantly 50 MHz and never changing,
++the clock set functions are not allowed to be used here, otherwise the PHY (ADIn1200) quits functioning.
++Actually, CONFIG_RMII is defined in the board specific header imx8mp_irma6r2.h  */
++#else
+ #if CONFIG_IS_ENABLED(CLK) && IS_ENABLED(CONFIG_IMX8)
+ 	if (!is_imx8dxl())
+ 		ret = clk_set_rate(&eqos->clk_tx, rate);
+ #else
+ 	ret = imx_eqos_txclk_set_rate(rate);
+ #endif
++#endif 
+ 	if (ret < 0) {
+ 		pr_err("imx (tx_clk, %lu) failed: %d", rate, ret);
+ 		return ret;
+@@ -1205,6 +1213,30 @@ static int eqos_start(struct udevice *dev)
+ 		goto err_stop_resets;
+ 	}
+ 
++#ifdef CONFIG_RMII
++/* The RMII interface isn't implemented correctly in this generic driver, only RGMII is served here. 
++Writing the EQOS_DMA_MODE_SWR bit resets the EQOS driver. 
++During this procedure, the GPR registers are read (again) which were set during the first boot process in function "setup_eqos" (imx8mp_irma6r2.c)
++During the first start of the EQOS driver, the GPR registers possibly aren't set yet, as "setup_eqos" wasn't called yet.
++That's why the SoC is convinced to use the default interface RGMII.
++The following code snippet resets the EQOS to be sure the GPR register is read with the correct value.
++It waits for closing the reset procedure, writes again and then waits for closing again.
++The first wait cycle above isn't aborted abruptly as the side effect isn't known. -
++Actually, CONFIG_RMII is defined in the board specific header imx8mp_irma6r2.h  */
++	val = readl(&eqos->dma_regs->mode);
++	val |= EQOS_DMA_MODE_SWR;
++	writel(val, &eqos->dma_regs->mode);
++
++    //Register auslesen
++	ret = wait_for_bit_le32(&eqos->dma_regs->mode,
++			EQOS_DMA_MODE_SWR, false,
++			eqos->config->swr_wait, false);
++	if (ret) {
++		pr_err("EQOS_DMA_MODE_SWR stuck after forced software reset");
++		goto err_stop_resets;
++	}
++#endif
++
+ 	ret = eqos->config->ops->eqos_calibrate_pads(dev);
+ 	if (ret < 0) {
+ 		pr_err("eqos_calibrate_pads() failed: %d", ret);
+diff --git a/include/configs/imx8mp_irma6r2.h b/include/configs/imx8mp_irma6r2.h
+index 72bcb8facd..cfe5af5e20 100644
+--- a/include/configs/imx8mp_irma6r2.h
++++ b/include/configs/imx8mp_irma6r2.h
+@@ -49,7 +49,8 @@
+ #if defined(CONFIG_CMD_NET)
+ #define CONFIG_ETHPRIME                 "eth1" /* Set eqos to primary since we use its MDIO */
+ 
+-#define CONFIG_FEC_XCV_TYPE             RGMII
++#define CONFIG_RMII
++#define CONFIG_FEC_XCV_TYPE             RMII
+ #define CONFIG_FEC_MXC_PHYADDR          1
+ #define FEC_QUIRK_ENET_MAC
+ 
+-- 
+2.20.1
+

--- a/recipes-bsp/u-boot/u-boot-imx_iris.inc
+++ b/recipes-bsp/u-boot/u-boot-imx_iris.inc
@@ -67,4 +67,5 @@ SRC_URI_append_imx8mp-irma6r2 = "\
 	file://0022-imx8mp-irma6r2-Add-CONFIG_ENV_FLAGS_LIST_STATIC.patch \
 	file://0023-imx8mp-irma6r2-Add-reset-after-bootcmd.patch \
 	file://0024-imx8mp_irma6r2_defconfig-Configure-writeable-list-su.patch \
+    file://0025-imx8mp_irma6r2-Generic-EQOS-driver-dwc_eth_qos.c-usable-for-RMII.patch \
 "

--- a/recipes-bsp/u-boot/u-boot-imx_iris.inc
+++ b/recipes-bsp/u-boot/u-boot-imx_iris.inc
@@ -67,5 +67,5 @@ SRC_URI_append_imx8mp-irma6r2 = "\
 	file://0022-imx8mp-irma6r2-Add-CONFIG_ENV_FLAGS_LIST_STATIC.patch \
 	file://0023-imx8mp-irma6r2-Add-reset-after-bootcmd.patch \
 	file://0024-imx8mp_irma6r2_defconfig-Configure-writeable-list-su.patch \
-    file://0025-imx8mp_irma6r2-Generic-EQOS-driver-dwc_eth_qos.c-usable-for-RMII.patch \
+	file://0025-imx8mp_irma6r2-Generic-EQOS-driver-dwc_eth_qos.c-usable-for-RMII.patch \
 "


### PR DESCRIPTION
imx8mp_irma6r2.h:
Introduced CONFIG_RMII;
changed CONFIG_FEC_XCV_TYPE to RMII
(although FEC isn't implemented actually)
Generic driver dwc_eth_qos.c:
Implemented workarounds RMII interface support
as it doesn't seem to be supported correctly in generic EQOS driver.
imx8mp-irma6r2.dts:
Added pin comments according to hardware schematic.