### PR TITLE
[RDPHOEN-1218] linux-fslc-iris: Add rtc patch

### DIFF
--- a/recipes-kernel/linux/linux-fslc-iris.inc
+++ b/recipes-kernel/linux/linux-fslc-iris.inc
@@ -39,7 +39,9 @@ SRC_URI += " \
     file://0031-tc358746.c-Reset-when-changing-format.patch \
     file://0032-imx8mp-irma6r2.dts-Change-memory-range-for-dsp.patch \
     file://0033-imx8mp-irma6r2.dts-Add-csi_mclk-to-pinctrl.patch \
-    file://0034-imx8mp-irma6r2.dts-Add-kernel-driver-for-eth0-ADIn1200-PHY.patch"
+    file://0034-imx8mp-irma6r2.dts-Add-kernel-driver-for-eth0-ADIn1200-PHY.patch \
+    file://0035-RDPHOEN-1218-Skip-registering-of-clkout-for-RTC.patch \
+"
 
 KERNEL_DEFCONFIG_imx8mpevk = "imx8mp-evk-r2_defconfig"
 KERNEL_DEFCONFIG_imx8mp-irma6r2 = "imx8mp_irma6r2_defconfig"

--- a/recipes-kernel/linux/linux-fslc-iris/0035-RDPHOEN-1218-Skip-registering-of-clkout-for-RTC.patch
+++ b/recipes-kernel/linux/linux-fslc-iris/0035-RDPHOEN-1218-Skip-registering-of-clkout-for-RTC.patch
@@ -1,0 +1,43 @@
+From 24200b046f33c40b5e5cccebf518158bf09ad710 Mon Sep 17 00:00:00 2001
+From: Erik Schumacher <erik.schumacher@iris-sensing.com>
+Date: Mon, 4 Jul 2022 13:57:19 +0200
+Subject: [PATCH] [RDPHOEN-1218] Skip registering of clkout for RTC
+
+Calling clk_disable_unused() later might hang in rtc pcf8563
+is_prepared() function. We don't use the clkout so we don't need to
+register the clock. So it is more or less a hot fix.
+---
+ arch/arm64/boot/dts/freescale/imx8mp-irma6r2.dts | 1 +
+ drivers/rtc/rtc-pcf8563.c                        | 4 +++-
+ 2 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/freescale/imx8mp-irma6r2.dts b/arch/arm64/boot/dts/freescale/imx8mp-irma6r2.dts
+index 388a0a2c8469..e5562fbb934a 100644
+--- a/arch/arm64/boot/dts/freescale/imx8mp-irma6r2.dts
++++ b/arch/arm64/boot/dts/freescale/imx8mp-irma6r2.dts
+@@ -349,6 +349,7 @@
+ 		compatible = "nxp,pcf8563";
+ 		reg = <0x51>;
+ 		#clock-cells = <0>;
++		skip-register-clkout;
+ 	};
+ };
+ 
+diff --git a/drivers/rtc/rtc-pcf8563.c b/drivers/rtc/rtc-pcf8563.c
+index 24baa4767b11..b76f795a50b7 100644
+--- a/drivers/rtc/rtc-pcf8563.c
++++ b/drivers/rtc/rtc-pcf8563.c
+@@ -610,7 +610,9 @@ static int pcf8563_probe(struct i2c_client *client,
+ 
+ #ifdef CONFIG_COMMON_CLK
+ 	/* register clk in common clk framework */
+-	pcf8563_clkout_register_clk(pcf8563);
++	if(!of_property_read_bool(client->dev.of_node, "skip-register-clkout")) {
++		pcf8563_clkout_register_clk(pcf8563);
++	}
+ #endif
+ 
+ 	return 0;
+-- 
+2.36.1
+


### PR DESCRIPTION
Skip register clk call to register the RTC clockout in the clock framework via a device tree flag.

On my hardware, using the irma6-fitimage-netboot had a 80% chance to hang up during boot. Testing with other set-ups might be difficult as you need a good way to get hang-ups during boot.