### PR TITLE
RDPHOEN-1226 Eth streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [APR's Version Numbering](https://apr.apache.org/ver
 - [RDPHOEN-1060]: Fix eqos driver in uboot to get ethernet working on release 2 hardware
 - [RDPHOEN-255]: Add Bootloader Update procedure for eMMC with SWUpdate
 - [RDPHOEN-1221]: Applying Iris Coporate Design to SWUpdate webinterface
+- [RDPHOEN-1226]: Adjust EPC660 & Serializer reset pins
+
 
 
 ### Changed

--- a/recipes-kernel/linux/linux-fslc-iris.inc
+++ b/recipes-kernel/linux/linux-fslc-iris.inc
@@ -41,6 +41,7 @@ SRC_URI += " \
     file://0033-imx8mp-irma6r2.dts-Add-csi_mclk-to-pinctrl.patch \
     file://0034-imx8mp-irma6r2.dts-Add-kernel-driver-for-eth0-ADIn1200-PHY.patch \
     file://0035-RDPHOEN-1218-Skip-registering-of-clkout-for-RTC.patch \
+    file://0036-imx8mp-irma6r2.dts-Adjust-EPC660-TC358746-reset-pins.patch \
 "
 
 KERNEL_DEFCONFIG_imx8mpevk = "imx8mp-evk-r2_defconfig"

--- a/recipes-kernel/linux/linux-fslc-iris/0036-imx8mp-irma6r2.dts-Adjust-EPC660-TC358746-reset-pins.patch
+++ b/recipes-kernel/linux/linux-fslc-iris/0036-imx8mp-irma6r2.dts-Adjust-EPC660-TC358746-reset-pins.patch
@@ -1,0 +1,74 @@
+From f9190acd527c5dc9046c11d34664c854df322e8c Mon Sep 17 00:00:00 2001
+From: Ian Dannapel <ian.dannapel@iris-sensing.com>
+Date: Mon, 4 Jul 2022 17:17:49 +0200
+Subject: [PATCH] imx8mp-irma6r2.dts: Adjust EPC660 & TC358746 reset pins
+
+Signed-off-by: Ian Dannapel <ian.dannapel@iris-sensing.com>
+---
+ .../boot/dts/freescale/imx8mp-irma6r2.dts      | 18 +++++++++++++-----
+ 1 file changed, 13 insertions(+), 5 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/freescale/imx8mp-irma6r2.dts b/arch/arm64/boot/dts/freescale/imx8mp-irma6r2.dts
+index d705691801d9..9032fc1794cf 100644
+--- a/arch/arm64/boot/dts/freescale/imx8mp-irma6r2.dts
++++ b/arch/arm64/boot/dts/freescale/imx8mp-irma6r2.dts
+@@ -179,8 +179,8 @@
+ 		reg = <0x22>;
+ 		status = "okay";
+ 		pinctrl-names = "default";
+-		pinctrl-0 = <&pinctrl_csi0_rst>, <&pinctrl_csi_mclk>;
+-		reset-gpios = <&gpio4 17 GPIO_ACTIVE_LOW>;
++		pinctrl-0 = <&pinctrl_csi0_rst_epc>, <&pinctrl_csi_mclk>;
++		reset-gpios = <&gpio4 24 GPIO_ACTIVE_LOW>;
+ 
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+@@ -189,7 +189,7 @@
+ 			reg = <0>;
+ 			epc660_parallel_out: endpoint {
+ 				bus-type = <5>;
+-				bus-width = <14>;
++				bus-width = <12>;
+ 				hsync-active = <0>;
+ 				vsync-active = <0>;
+ 				field-even-active = <0>;
+@@ -206,6 +206,8 @@
+ 		
+ 		clocks = <&clk_serializer>;
+ 		default-input = <0>;
++		pinctrl-0 = <&pinctrl_csi0_rst_bridge>;
++		reset-gpios = <&gpio4 17 GPIO_ACTIVE_LOW>;
+ 		
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+@@ -214,7 +216,7 @@
+ 			reg = <0>;
+ 			tc358748_parallel_in: endpoint {
+ 				bus-type = <5>;
+-				bus-width = <14>;
++				bus-width = <12>;
+ 				hsync-active = <0>;
+ 				vsync-active = <0>;
+ 				field-even-active = <0>;
+@@ -748,11 +750,17 @@
+ 		>;
+ 	};
+ 
+-	pinctrl_csi0_rst: csi0_rst_grp {
++	pinctrl_csi0_rst_bridge: csi0_rst_grp {
+ 		fsl,pins = <
+ 			MX8MP_IOMUXC_SAI1_TXD5__GPIO4_IO17		0x19
+ 		>;
+ 	};
++	
++	pinctrl_csi0_rst_epc: csi0_rst_grp2 {
++		fsl,pins = <
++			MX8MP_IOMUXC_SAI2_TXFS__GPIO4_IO24		0x19
++		>;
++	};
+ 
+ 	pinctrl_csi_mclk: csi_mclk_grp {
+ 		fsl,pins = <
+-- 
+2.25.1
+


### PR DESCRIPTION
[Jenkins with HAL/Imager dependency included](https://jenkins.devops.defra01.iris-sensing.net/blue/organizations/jenkins/meta-iris/detail/feature%2Fiada%2FRDPHOEN-1226_ETH_Streaming/2/pipeline)

How to test:

1. Review and approve dependency: [PR Hal Imager](https://bitbucket.iris-sensing.net/projects/COMP/repos/hal_imager/pull-requests/102/overview)
2. Flash the Jenkins artifacts.
3. Boot the board and start count_von_count
4. Confirm that ToF streaming and counting is working on the webinterface visualization section.