### PR TITLE
[RDPHOEN-1191] enable u-boot watchdog

### DIFF
--- a/recipes-bsp/u-boot/u-boot-imx/imx8mp-irma6r2/0026-imx8mp_irma6r2-enable-bootloader-watchdog.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/imx8mp-irma6r2/0026-imx8mp_irma6r2-enable-bootloader-watchdog.patch
@@ -1,0 +1,132 @@
+From e60b8bacb4287ae8fab3c17b99aaf1cbb711d4db Mon Sep 17 00:00:00 2001
+From: sven-foerster <sven.foerster@iris-sensing.com>
+Date: Mon, 4 Jul 2022 16:42:24 +0200
+Subject: [PATCH] [RDPHOEN-1191] enable bootloader watchdog
+
+Signed-off-by: sven-foerster <sven.foerster@iris-sensing.com>
+---
+ board/freescale/imx8mp_irma6r2/imx8mp_irma6r2.c | 15 +++++++++++++++
+ configs/imx8mp_irma6r2_defconfig                |  2 ++
+ include/bootcount.h                             |  6 ++++++
+ include/watchdog.h                              | 14 +++++++++++---
+ 4 files changed, 34 insertions(+), 3 deletions(-)
+
+diff --git a/board/freescale/imx8mp_irma6r2/imx8mp_irma6r2.c b/board/freescale/imx8mp_irma6r2/imx8mp_irma6r2.c
+index 0ee39d23b6..dab5ddbe4c 100644
+--- a/board/freescale/imx8mp_irma6r2/imx8mp_irma6r2.c
++++ b/board/freescale/imx8mp_irma6r2/imx8mp_irma6r2.c
+@@ -28,6 +28,7 @@
+ DECLARE_GLOBAL_DATA_PTR;
+ 
+ #define DEBUG 0
++#define DBG_WATCHDOG 0
+ 
+ #define UART_PAD_CTRL	(PAD_CTL_DSE6 | PAD_CTL_FSEL1)
+ #define WDOG_PAD_CTRL	(PAD_CTL_DSE6 | PAD_CTL_ODE | PAD_CTL_PUE | PAD_CTL_PE)
+@@ -523,7 +524,11 @@ void board_autogenerate_bootcmd (void)
+     int firmware_env = env_get_ulong("firmware", 10, 0);
+     char *firmware;
+     char *altfirmware;
++#if DBG_WATCHDOG
++    char bootcmd[100];
++#else
+     char bootcmd[50];
++#endif
+     char altbootcmd[50];
+     char partboot[20];
+     char altpartboot[20];
+@@ -534,6 +539,12 @@ void board_autogenerate_bootcmd (void)
+     printf("Active firmware: %d. ustate: %d \n", firmware_env, ustate);
+ #endif
+ 
++#if DBG_WATCHDOG
++    upgrade_available = 1;
++    env_set_ulong("upgrade_available", upgrade_available);
++    printf("Info: upgrade_available=%d\n", upgrade_available);
++#endif
++
+     if ( (upgrade_available == 1) && ( ustate == 1) )
+     {
+         /* Change the boot firmware:  */
+@@ -581,7 +592,11 @@ void board_autogenerate_bootcmd (void)
+     snprintf(altpartboot, sizeof(altpartboot), "linuxboot_%s", altfirmware);
+     /* "reset;" as a security desgin pattern "so that any failure of the bootcmd does not leave you 
+     in an insecure U-Boot console environment." -- http://trac.gateworks.com/wiki/secure_boot  */
++#if DBG_WATCHDOG
++    snprintf(bootcmd, sizeof(bootcmd), "setenv mmcpart %s; while true; do sleep %d; echo %s; done; run fitboot; reset;", partboot, 10, " wait 10sec ..");
++#else
+     snprintf(bootcmd, sizeof(bootcmd), "setenv mmcpart %s; run fitboot; reset;", partboot);
++#endif
+     snprintf(altbootcmd, sizeof(altbootcmd), "setenv mmcpart %s; run fitboot; reset;", altpartboot);
+ #if DEBUG
+     printf("partboot: %s  ... altpartboot: %s \n", partboot, altpartboot);
+diff --git a/configs/imx8mp_irma6r2_defconfig b/configs/imx8mp_irma6r2_defconfig
+index 6aa47245f1..16c77b931b 100644
+--- a/configs/imx8mp_irma6r2_defconfig
++++ b/configs/imx8mp_irma6r2_defconfig
+@@ -139,4 +139,6 @@ CONFIG_VIDEO_LCD_RAYDIUM_RM67191=y
+ CONFIG_VIDEO_IMX_SEC_DSI=y
+ CONFIG_VIDEO_IMX_LCDIFV3=y
+ CONFIG_VIDEO_ADV7535=y
++CONFIG_WATCHDOG_RESET_DISABLE=y
++CONFIG_IMX_WATCHDOG=y
+ CONFIG_OF_LIBFDT_OVERLAY=y
+diff --git a/include/bootcount.h b/include/bootcount.h
+index cd30403984..b0edcacf55 100644
+--- a/include/bootcount.h
++++ b/include/bootcount.h
+@@ -11,6 +11,8 @@
+ #include <asm/byteorder.h>
+ #include <env.h>
+ 
++#define DBG_BOOTCOUNT 1
++
+ #ifdef CONFIG_DM_BOOTCOUNT
+ 
+ struct bootcount_ops {
+@@ -123,6 +125,10 @@ static inline void bootcount_inc(void)
+ {
+ 	unsigned long bootcount = bootcount_load();
+ 
++#if DBG_BOOTCOUNT
++	printf("Info: bootcount=%lu\n", bootcount);
++#endif
++
+ 	if (gd->flags & GD_FLG_SPL_INIT) {
+ 		bootcount_store(++bootcount);
+ 		return;
+diff --git a/include/watchdog.h b/include/watchdog.h
+index a4a4e8e614..628c0469c2 100644
+--- a/include/watchdog.h
++++ b/include/watchdog.h
+@@ -32,6 +32,10 @@ int init_func_watchdog_reset(void);
+ #  error "Configuration error: CONFIG_HW_WATCHDOG and CONFIG_WATCHDOG can't be used together."
+ #endif
+ 
++static inline void imx_dummy_watchdog_reset(void)
++{
++}
++
+ /*
+  * Hardware watchdog
+  */
+@@ -39,9 +43,13 @@ int init_func_watchdog_reset(void);
+ 	#if defined(__ASSEMBLY__)
+ 		#define WATCHDOG_RESET bl hw_watchdog_reset
+ 	#else
+-		extern void hw_watchdog_reset(void);
+-
+-		#define WATCHDOG_RESET hw_watchdog_reset
++		#if defined(CONFIG_IMX_WATCHDOG) && defined(CONFIG_WATCHDOG_RESET_DISABLE)
++			void imx_dummy_watchdog_reset(void);
++			#define WATCHDOG_RESET imx_dummy_watchdog_reset
++		#else
++			extern void hw_watchdog_reset(void);
++			#define WATCHDOG_RESET hw_watchdog_reset
++		#endif /* CONFIG_IMX_WATCHDOG && CONFIG_WATCHDOG_RESET_DISABLE */
+ 	#endif /* __ASSEMBLY__ */
+ #else
+ 	/*
+-- 
+2.17.1
+

--- a/recipes-bsp/u-boot/u-boot-imx/imx8mpevk/0014-imx8mp_evk-enable-u-boot-watchdog.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/imx8mpevk/0014-imx8mp_evk-enable-u-boot-watchdog.patch
@@ -1,0 +1,132 @@
+From d30f32d7e22e1da7aa5b166becfe78d6fd90ae6a Mon Sep 17 00:00:00 2001
+From: sven-foerster <sven.foerster@iris-sensing.com>
+Date: Sun, 3 Jul 2022 17:57:26 +0200
+Subject: [PATCH] {RDPHOEN-1191] enable u-boot watchdog
+
+Signed-off-by: sven-foerster <sven.foerster@iris-sensing.com>
+---
+ board/freescale/imx8mp_evk/imx8mp_evk.c | 15 +++++++++++++++
+ configs/imx8mp_evk_defconfig            |  2 ++
+ include/bootcount.h                     |  6 ++++++
+ include/watchdog.h                      | 14 +++++++++++---
+ 4 files changed, 34 insertions(+), 3 deletions(-)
+
+diff --git a/board/freescale/imx8mp_evk/imx8mp_evk.c b/board/freescale/imx8mp_evk/imx8mp_evk.c
+index 74b18f5b13..899f27cb1c 100644
+--- a/board/freescale/imx8mp_evk/imx8mp_evk.c
++++ b/board/freescale/imx8mp_evk/imx8mp_evk.c
+@@ -26,6 +26,7 @@
+ DECLARE_GLOBAL_DATA_PTR;
+ 
+ #define DEBUG 0
++#define DBG_WATCHDOG 0
+ 
+ #define UART_PAD_CTRL	(PAD_CTL_DSE6 | PAD_CTL_FSEL1)
+ #define WDOG_PAD_CTRL	(PAD_CTL_DSE6 | PAD_CTL_ODE | PAD_CTL_PUE | PAD_CTL_PE)
+@@ -507,7 +508,11 @@ void board_autogenerate_bootcmd (void)
+     int firmware_env = env_get_ulong("firmware", 10, 0);
+     char *firmware;
+     char *altfirmware;
++#if DBG_WATCHDOG
++    char bootcmd[100];
++#else
+     char bootcmd[50];
++#endif
+     char altbootcmd[50];
+     char partboot[20];
+     char altpartboot[20];
+@@ -518,6 +523,12 @@ void board_autogenerate_bootcmd (void)
+     printf("Active firmware: %d. ustate: %d \n", firmware_env, ustate);
+ #endif
+ 
++#if DBG_WATCHDOG
++    upgrade_available = 1;
++    env_set_ulong("upgrade_available", upgrade_available);
++    printf("Info: upgrade_available=%d\n", upgrade_available);
++#endif
++
+     if ( (upgrade_available == 1) && ( ustate == 1) )
+     {
+         /* Change the boot firmware:  */
+@@ -565,7 +576,11 @@ void board_autogenerate_bootcmd (void)
+     snprintf(altpartboot, sizeof(altpartboot), "linuxboot_%s", altfirmware);
+     /* "reset;" as a security desgin pattern "so that any failure of the bootcmd does not leave you 
+     in an insecure U-Boot console environment." -- http://trac.gateworks.com/wiki/secure_boot  */
++#if DBG_WATCHDOG
++    snprintf(bootcmd, sizeof(bootcmd), "setenv mmcpart %s; while true; do sleep %d; echo %s; done; run fitboot; reset;", partboot, 10, " wait 10sec ..");
++#else
+     snprintf(bootcmd, sizeof(bootcmd), "setenv mmcpart %s; run fitboot; reset;", partboot);
++#endif
+     snprintf(altbootcmd, sizeof(altbootcmd), "setenv mmcpart %s; run fitboot; reset;", altpartboot);
+ #if DEBUG
+     printf("partboot: %s  ... altpartboot: %s \n", partboot, altpartboot);
+diff --git a/configs/imx8mp_evk_defconfig b/configs/imx8mp_evk_defconfig
+index 8029d831b1..7f0bc250df 100644
+--- a/configs/imx8mp_evk_defconfig
++++ b/configs/imx8mp_evk_defconfig
+@@ -133,4 +133,6 @@ CONFIG_VIDEO_LCD_RAYDIUM_RM67191=y
+ CONFIG_VIDEO_IMX_SEC_DSI=y
+ CONFIG_VIDEO_IMX_LCDIFV3=y
+ CONFIG_VIDEO_ADV7535=y
++CONFIG_WATCHDOG_RESET_DISABLE=y
++CONFIG_IMX_WATCHDOG=y
+ CONFIG_OF_LIBFDT_OVERLAY=y
+diff --git a/include/bootcount.h b/include/bootcount.h
+index cd30403984..b0edcacf55 100644
+--- a/include/bootcount.h
++++ b/include/bootcount.h
+@@ -11,6 +11,8 @@
+ #include <asm/byteorder.h>
+ #include <env.h>
+ 
++#define DBG_BOOTCOUNT 1
++
+ #ifdef CONFIG_DM_BOOTCOUNT
+ 
+ struct bootcount_ops {
+@@ -123,6 +125,10 @@ static inline void bootcount_inc(void)
+ {
+ 	unsigned long bootcount = bootcount_load();
+ 
++#if DBG_BOOTCOUNT
++	printf("Info: bootcount=%lu\n", bootcount);
++#endif
++
+ 	if (gd->flags & GD_FLG_SPL_INIT) {
+ 		bootcount_store(++bootcount);
+ 		return;
+diff --git a/include/watchdog.h b/include/watchdog.h
+index a4a4e8e614..628c0469c2 100644
+--- a/include/watchdog.h
++++ b/include/watchdog.h
+@@ -32,6 +32,10 @@ int init_func_watchdog_reset(void);
+ #  error "Configuration error: CONFIG_HW_WATCHDOG and CONFIG_WATCHDOG can't be used together."
+ #endif
+ 
++static inline void imx_dummy_watchdog_reset(void)
++{
++}
++
+ /*
+  * Hardware watchdog
+  */
+@@ -39,9 +43,13 @@ int init_func_watchdog_reset(void);
+ 	#if defined(__ASSEMBLY__)
+ 		#define WATCHDOG_RESET bl hw_watchdog_reset
+ 	#else
+-		extern void hw_watchdog_reset(void);
+-
+-		#define WATCHDOG_RESET hw_watchdog_reset
++		#if defined(CONFIG_IMX_WATCHDOG) && defined(CONFIG_WATCHDOG_RESET_DISABLE)
++			void imx_dummy_watchdog_reset(void);
++			#define WATCHDOG_RESET imx_dummy_watchdog_reset
++		#else
++			extern void hw_watchdog_reset(void);
++			#define WATCHDOG_RESET hw_watchdog_reset
++		#endif /* CONFIG_IMX_WATCHDOG && CONFIG_WATCHDOG_RESET_DISABLE */
+ 	#endif /* __ASSEMBLY__ */
+ #else
+ 	/*
+-- 
+2.17.1
+

--- a/recipes-bsp/u-boot/u-boot-imx_iris.inc
+++ b/recipes-bsp/u-boot/u-boot-imx_iris.inc
@@ -42,6 +42,7 @@ SRC_URI_append_imx8mpevk = "\
 	file://0011-imx8mpevk-Add-reset-after-bootcmd.patch \
 	file://0012-imx8mp-evk-Add-CONFIG_ENV_FLAGS_LIST_STATIC.patch \
 	file://0013-imx8mp_evk_defconfig-Configure-writeable-list-suppor.patch \
+	file://0014-imx8mp_evk-enable-u-boot-watchdog.patch \
 "
 
 FILESEXTRAPATHS_prepend_imx8mp-irma6r2 := "${THISDIR}/u-boot-imx/imx8mp-irma6r2:"
@@ -71,4 +72,5 @@ SRC_URI_append_imx8mp-irma6r2 = "\
 	file://0023-imx8mp-irma6r2-Add-reset-after-bootcmd.patch \
 	file://0024-imx8mp_irma6r2_defconfig-Configure-writeable-list-su.patch \
 	file://0025-imx8mp_irma6r2-Generic-EQOS-driver-dwc_eth_qos.c-usable-for-RMII.patch \
+	file://0026-imx8mp_irma6r2-enable-bootloader-watchdog.patch \
 "


### PR DESCRIPTION
**_1)_** Prepare Test by the following:
change in
meta-iris-base/recipes-bsp/u-boot/u-boot-imx/imx8mp-irma6r2/0026-imx8mp_irma6r2-enable-bootloader-watchdog.patch
line 22
from:
+#define DBG_WATCHDOG **0**
to:
+#define DBG_WATCHDOG **1**

... and build for "imx8mp-irma6r2" with e.g.:
"bitbake mc:imx8mp-irma6r2:irma6-base-uuu"

**_2)_** Test:
after flashing start the board and wait ...

**_After _bootcount_ counted from _1 to 5_ (see below console output fragments)_**
...
Info: **upgrade_available=1**
flash target is MMC:2  
...
Info: **bootcount=1**
Saving Environment to MMC... Writing to redundant MMC(2)... OK
Normal Boot
Hit any key to stop autoboot:  0
wait 10sec ..
wait 10sec ..
wait 10sec ..
wait 10sec ..
wait 10sec ..

**_u-boot reboot after 1 min (3 times)_**
...

Info: **upgrade_available=1**
flash target is MMC:2  
...
Info: **bootcount=4**
Saving Environment to MMC... Writing to MMC(2)... OK
Normal Boot
Hit any key to stop autoboot:  0
wait 10sec ..
wait 10sec ..
wait 10sec ..
wait 10sec ..
wait 10sec ..

**_u-boot reboot after 1 min_**

Info: **upgrade_available=1**
flash target is MMC:2
...
Info: **bootcount=5**
Saving Environment to MMC... Writing to redundant MMC(2)... OK
Normal Boot
Warning: Bootlimit (5) exceeded. **Using altbootcmd.**
Hit any key to stop autoboot:  0
...
Authenticate image from DDR location 0x48000000...
...
Secure boot disabled
...
**Loading kernel from FIT Image at 48000000 ...**
...
Select firmware_b
Root mnt   : /mnt
Root device: /dev/mapper/irma6lvm-rootfs_b
Crypt device: /dev/mapper/decrypted-irma6lvm-rootfs_b
Verity device: /dev/mapper/verity-rootfs_b
733001959
Unlocking encrypted device: /dev/mapper/irma6lvm-rootfs_b
Unlocking encrypted device: /dev/mapper/irma6lvm-userdata
Opening verity device: /dev/mapper/decrypted-irma6lvm-rootfs_b
...
imx8mp-irma6r2 login: 