### PR TITLE
[RDPHOEN-1220/RDPHOEN-1225] IU EEPROM readout in bootloader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ and this project adheres to [APR's Version Numbering](https://apr.apache.org/ver
 - [DEVOPS-522]: Add dev keys for swupdate signing, move existing keys from iris-kas repo to meta-iris-base
 - [RDPHOEN-1120]: swupdate: Enable support for signed images
 - [RDPHOEN-1120]: swupdate: Enable support for encrypted images
+- [RDPHOEN-1220]: Add IU EEPROM readout for nfs boot flag
+- [RDPHOEN-1225]: Add IU EEPROM readout for mac address
 
 ### Changed
 - [DEVOPS-519] Moved config from iris-kas local.conf to meta-iris-base distro.conf

--- a/classes/irma6-bootloader-version.bbclass
+++ b/classes/irma6-bootloader-version.bbclass
@@ -4,4 +4,4 @@
 # partition. A signed storage location in flash.bin is the u-boot and the
 # u-boot-spl.
 
-IRIS_IMX_BOOT_RELEASE = "iris-boot_0.1.0"
+IRIS_IMX_BOOT_RELEASE = "iris-boot_0.1.1"

--- a/recipes-bsp/u-boot/u-boot-imx/imx8mp-irma6r2/0026-imx8mp-irma6r2-Add-i2c4-to-bootloader-device-tree-fo.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/imx8mp-irma6r2/0026-imx8mp-irma6r2-Add-i2c4-to-bootloader-device-tree-fo.patch
@@ -1,0 +1,91 @@
+From 7684b381b2953581b6fb17f5ba4bfcaaea6ea11b Mon Sep 17 00:00:00 2001
+From: "philipp.schoewe" <Philipp.Schoewe@iris-sensing.com>
+Date: Thu, 7 Jul 2022 11:33:50 +0200
+Subject: [PATCH] imx8mp-irma6r2: Add i2c4 to bootloader device tree for
+ accessing IU EEPROM
+
+---
+ arch/arm/dts/imx8mp-irma6r2-u-boot.dtsi |  4 ++++
+ arch/arm/dts/imx8mp-irma6r2.dts         | 24 ++++++++++++++++++++++++
+ configs/imx8mp_irma6r2_defconfig        |  1 +
+ 3 files changed, 29 insertions(+)
+
+diff --git a/arch/arm/dts/imx8mp-irma6r2-u-boot.dtsi b/arch/arm/dts/imx8mp-irma6r2-u-boot.dtsi
+index 1e5aa03a73..71f4c090f4 100644
+--- a/arch/arm/dts/imx8mp-irma6r2-u-boot.dtsi
++++ b/arch/arm/dts/imx8mp-irma6r2-u-boot.dtsi
+@@ -113,6 +113,10 @@
+ 	u-boot,dm-spl;
+ };
+ 
++&i2c4 {
++	u-boot,dm-spl;
++};
++
+ &pinctrl_i2c1 {
+ 	u-boot,dm-spl;
+ };
+diff --git a/arch/arm/dts/imx8mp-irma6r2.dts b/arch/arm/dts/imx8mp-irma6r2.dts
+index ade7adadd0..8ad012e66c 100644
+--- a/arch/arm/dts/imx8mp-irma6r2.dts
++++ b/arch/arm/dts/imx8mp-irma6r2.dts
+@@ -281,6 +281,16 @@
+ 	};
+ };
+ 
++&i2c4 {
++	clock-frequency = <100000>;
++	pinctrl-names = "default", "gpio";
++	pinctrl-0 = <&pinctrl_i2c4>;
++	pinctrl-1 = <&pinctrl_i2c4_gpio>;
++	scl-gpios = <&gpio5 20 GPIO_ACTIVE_HIGH>;
++	sda-gpios = <&gpio5 21 GPIO_ACTIVE_HIGH>;
++	status = "okay";
++};
++
+ &lcdif1 {
+ 	status = "okay";
+ };
+@@ -432,6 +442,13 @@
+ 		>;
+ 	};
+ 
++	pinctrl_i2c4: i2c4grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_I2C4_SCL__I2C4_SCL			0x400001c3
++			MX8MP_IOMUXC_I2C4_SDA__I2C4_SDA			0x400001c3
++		>;
++	};
++
+ 	pinctrl_i2c1_gpio: i2c1grp-gpio {
+ 		fsl,pins = <
+ 			MX8MP_IOMUXC_I2C1_SCL__GPIO5_IO14        	0x1c3
+@@ -453,6 +470,13 @@
+ 		>;
+ 	};
+ 
++	pinctrl_i2c4_gpio: i2c4grp-gpio {
++		fsl,pins = <
++			MX8MP_IOMUXC_I2C4_SCL__GPIO5_IO20        	0x1c3
++			MX8MP_IOMUXC_I2C4_SDA__GPIO5_IO21        	0x1c3
++		>;
++	};
++
+ 	pinctrl_mipi_dsi_en: mipi_dsi_en {
+ 		fsl,pins = <
+ 			MX8MP_IOMUXC_GPIO1_IO08__GPIO1_IO08	0x16
+diff --git a/configs/imx8mp_irma6r2_defconfig b/configs/imx8mp_irma6r2_defconfig
+index 6aa47245f1..72788ea26e 100644
+--- a/configs/imx8mp_irma6r2_defconfig
++++ b/configs/imx8mp_irma6r2_defconfig
+@@ -9,6 +9,7 @@ CONFIG_SPL_LIBGENERIC_SUPPORT=y
+ CONFIG_SYS_I2C_MXC_I2C1=y
+ CONFIG_SYS_I2C_MXC_I2C2=y
+ CONFIG_SYS_I2C_MXC_I2C3=y
++CONFIG_SYS_I2C_MXC_I2C4=y
+ CONFIG_ENV_SIZE=0x2000
+ CONFIG_ENV_OFFSET=0x400000
+ CONFIG_DM_GPIO=y
+-- 
+2.25.1
+

--- a/recipes-bsp/u-boot/u-boot-imx/imx8mp-irma6r2/0027-imx8mp-irma6r2-Add-IU-EEPROM-readout-for-configuring.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/imx8mp-irma6r2/0027-imx8mp-irma6r2-Add-IU-EEPROM-readout-for-configuring.patch
@@ -1,0 +1,334 @@
+From ec853d051e5ee44f57108cab364cc14e864ccaf6 Mon Sep 17 00:00:00 2001
+From: "philipp.schoewe" <Philipp.Schoewe@iris-sensing.com>
+Date: Fri, 8 Jul 2022 14:20:18 +0200
+Subject: [PATCH] imx8mp-irma6r2: Add IU EEPROM readout for configuring mac
+ address and nfs boot
+
+---
+ board/freescale/imx8mp_irma6r2/Makefile       |   2 +
+ board/freescale/imx8mp_irma6r2/i2c_memory.c   |  63 +++++++++
+ board/freescale/imx8mp_irma6r2/i2c_memory.h   |  11 ++
+ .../freescale/imx8mp_irma6r2/imx8mp_irma6r2.c |  27 +++-
+ .../freescale/imx8mp_irma6r2/interface_unit.c | 132 ++++++++++++++++++
+ .../freescale/imx8mp_irma6r2/interface_unit.h |  24 ++++
+ 6 files changed, 252 insertions(+), 7 deletions(-)
+ create mode 100644 board/freescale/imx8mp_irma6r2/i2c_memory.c
+ create mode 100644 board/freescale/imx8mp_irma6r2/i2c_memory.h
+ create mode 100644 board/freescale/imx8mp_irma6r2/interface_unit.c
+ create mode 100644 board/freescale/imx8mp_irma6r2/interface_unit.h
+
+diff --git a/board/freescale/imx8mp_irma6r2/Makefile b/board/freescale/imx8mp_irma6r2/Makefile
+index d72fe0c253..304a81bd52 100644
+--- a/board/freescale/imx8mp_irma6r2/Makefile
++++ b/board/freescale/imx8mp_irma6r2/Makefile
+@@ -6,6 +6,8 @@
+ #
+ 
+ obj-y += imx8mp_irma6r2.o
++obj-y += i2c_memory.o
++obj-y += interface_unit.o
+ 
+ ifdef CONFIG_SPL_BUILD
+ obj-y += spl.o
+diff --git a/board/freescale/imx8mp_irma6r2/i2c_memory.c b/board/freescale/imx8mp_irma6r2/i2c_memory.c
+new file mode 100644
+index 0000000000..e76b4ada48
+--- /dev/null
++++ b/board/freescale/imx8mp_irma6r2/i2c_memory.c
+@@ -0,0 +1,63 @@
++#include "i2c_memory.h"
++#include <i2c.h>
++
++/**
++ * write_memory - write the content into EEPROM/FRAM
++ */
++int write_memory(unsigned int bus, uint8_t chip, unsigned int addr,
++		uint8_t *buffer, int len) {
++	struct udevice* _bus;
++	struct udevice* i2c_dev = NULL;
++	int ret;
++
++	ret = uclass_get_device_by_seq(UCLASS_I2C, bus, &_bus);
++	if (ret) {
++		printf("%s: Can't find bus\n", __func__);
++		return -EINVAL;
++	}
++
++	ret = dm_i2c_probe(_bus, chip, 0, &i2c_dev);
++	if (ret) {
++		printf("%s: Can't find device id=0x%x\n",
++			__func__, chip);
++		return -ENODEV;
++	}
++
++	ret = dm_i2c_write(i2c_dev, addr, (const uint8_t *)buffer, len);
++	if (ret) {
++		printf("%s dm_i2c_write failed, err %d\n", __func__, ret);
++		return -EIO;
++	}
++	return 0;
++}
++
++/**
++ * read_memory - read the EEPROM/FRAM content into memory
++ */
++int read_memory(unsigned int bus, uint8_t chip, unsigned int addr,
++		uint8_t *buffer, int len) {
++	struct udevice* _bus;
++	struct udevice* i2c_dev = NULL;
++	int ret;
++
++	ret = uclass_get_device_by_seq(UCLASS_I2C, bus, &_bus);
++	if (ret) {
++		printf("%s: Can't find bus\n", __func__);
++		return -EINVAL;
++	}
++
++	ret = dm_i2c_probe(_bus, chip, 0, &i2c_dev);
++	if (ret) {
++		printf("%s: Can't find device id=0x%x\n",
++			__func__, addr);
++		return -ENODEV;
++	}
++
++	ret = dm_i2c_read(i2c_dev, addr, buffer, len);
++	if (ret) {
++		printf("%s dm_i2c_read failed, err %d\n", __func__, ret);
++		return -EIO;
++	}
++	return 0;
++}
++
+diff --git a/board/freescale/imx8mp_irma6r2/i2c_memory.h b/board/freescale/imx8mp_irma6r2/i2c_memory.h
+new file mode 100644
+index 0000000000..c88f93496a
+--- /dev/null
++++ b/board/freescale/imx8mp_irma6r2/i2c_memory.h
+@@ -0,0 +1,11 @@
++#ifndef BOARD_IMX8MP_I2C_MEMORY_H_
++#define BOARD_IMX8MP_I2C_MEMORY_H_
++
++#include <common.h>
++
++int write_memory(unsigned int bus, uint8_t chip, unsigned int addr,
++		uint8_t *buffer, int len);
++int read_memory(unsigned int bus, uint8_t chip, unsigned int addr,
++		uint8_t *buffer, int len);
++
++#endif /* BOARD_IMX8MP_I2C_MEMORY_H_ */
+diff --git a/board/freescale/imx8mp_irma6r2/imx8mp_irma6r2.c b/board/freescale/imx8mp_irma6r2/imx8mp_irma6r2.c
+index 0ee39d23b6..42cc2956c0 100644
+--- a/board/freescale/imx8mp_irma6r2/imx8mp_irma6r2.c
++++ b/board/freescale/imx8mp_irma6r2/imx8mp_irma6r2.c
+@@ -24,6 +24,7 @@
+ #include <dwc3-uboot.h>
+ #include <mmc.h>
+ #include "bootcount.h"
++#include "interface_unit.h"
+ 
+ DECLARE_GLOBAL_DATA_PTR;
+ 
+@@ -576,13 +577,25 @@ void board_autogenerate_bootcmd (void)
+ #endif
+     }
+ 
+-    /* Combine the (alt)bootcmd according to the change of variable "firmware" */
+-    snprintf(partboot, sizeof(partboot), "linuxboot_%s", firmware);
+-    snprintf(altpartboot, sizeof(altpartboot), "linuxboot_%s", altfirmware);
+-    /* "reset;" as a security desgin pattern "so that any failure of the bootcmd does not leave you 
+-    in an insecure U-Boot console environment." -- http://trac.gateworks.com/wiki/secure_boot  */
+-    snprintf(bootcmd, sizeof(bootcmd), "setenv mmcpart %s; run fitboot; reset;", partboot);
+-    snprintf(altbootcmd, sizeof(altbootcmd), "setenv mmcpart %s; run fitboot; reset;", altpartboot);
++	/* read interface unit eeprom for nfs boot flag and mac address */
++	bool nfs_boot = false;
++	if (IU_read_eeprom() == 0) {
++		IU_print_eeprom_content();
++		IU_set_mac("eth1addr");
++		nfs_boot = IU_get_nfs_boot_flag();
++	}
++	
++	if (nfs_boot) {
++		snprintf(bootcmd, sizeof(bootcmd), "run netfitboot; reset;");
++	} else {
++		/* Combine the (alt)bootcmd according to the change of variable "firmware" */
++		snprintf(partboot, sizeof(partboot), "linuxboot_%s", firmware);
++		snprintf(altpartboot, sizeof(altpartboot), "linuxboot_%s", altfirmware);
++		/* "reset;" as a security desgin pattern "so that any failure of the bootcmd does not leave you 
++		in an insecure U-Boot console environment." -- http://trac.gateworks.com/wiki/secure_boot  */
++		snprintf(bootcmd, sizeof(bootcmd), "setenv mmcpart %s; run fitboot; reset;", partboot);
++		snprintf(altbootcmd, sizeof(altbootcmd), "setenv mmcpart %s; run fitboot; reset;", altpartboot);
++	}
+ #if DEBUG
+     printf("partboot: %s  ... altpartboot: %s \n", partboot, altpartboot);
+     printf("bootcmd: %s . altbootcmd: %s \n", bootcmd, altbootcmd);
+diff --git a/board/freescale/imx8mp_irma6r2/interface_unit.c b/board/freescale/imx8mp_irma6r2/interface_unit.c
+new file mode 100644
+index 0000000000..ae499dc144
+--- /dev/null
++++ b/board/freescale/imx8mp_irma6r2/interface_unit.c
+@@ -0,0 +1,132 @@
++#include "interface_unit.h"
++#include <common.h>
++#include <command.h>
++#include <linux/ctype.h>
++#include "i2c_memory.h"
++
++#define IU_EEPROM_ADDR 	0x51
++#define IU_EEPROM_BUS_NUM 	3
++
++#define IU_BASE_ADDR        0x00 /* EEPROM Base Address */
++#define IU_CIB_ADDR         0x00 /* Component Identification Block */
++#define IU_CIB_VERSION_ADDR 0x04
++#define IU_BCB_ADDR         0x10 /* Interface Configuration Block */
++#define IU_MAC_ADDR         0x11 /* EEPROM MAC Address */
++#define IU_BCB_FLAGS_ADDR   0x1F
++#define IU_BCB_VERSION_ADDR 0x10
++
++#define IU_EEPROM_BLOCK_MAGIC { 0x49, 0x52, 0x49, 0x53 }
++#define IU_CIB_VERSION 0x01
++#define IU_BCB_VERSION 0x02
++
++struct __attribute__ ((__packed__)) component_identification_block {
++	uint8_t magic[4];
++	uint8_t version;
++	uint8_t flags;
++	uint8_t comp_ident;
++	uint8_t revision;
++	uint8_t sn[6];
++	uint8_t reserved[2];
++};
++
++struct __attribute__ ((__packed__)) interface_configuration_block {
++	uint8_t version;
++	uint8_t mac[6];
++	uint8_t dn[8];
++	struct bcb_flags_t {
++		uint8_t nfs :1, dhcp :1, reserved :6;
++	} flags;
++};
++
++static struct __attribute__ ((__packed__)) interface_eeprom {
++	struct component_identification_block cib;
++	struct interface_configuration_block bcb;
++} eeprom;
++
++enum eeprom_validity_state {
++	VALID = 0, INVALID = 1
++};
++
++static enum eeprom_validity_state eeprom_cib_state = INVALID;
++static enum eeprom_validity_state eeprom_bcb_state = INVALID;
++
++static enum eeprom_validity_state compare_versions(uint8_t version_in_hardware, uint8_t current_version) {
++	if (version_in_hardware == current_version) {
++		return VALID;
++	}
++	return INVALID;
++}
++
++static enum eeprom_validity_state validate_cib_content(struct component_identification_block * cib) {
++	/* check magic number */
++	uint8_t MAGIC[4] = IU_EEPROM_BLOCK_MAGIC;
++	if (memcmp(cib->magic, MAGIC, 4)) {
++		return INVALID;
++	}
++	return compare_versions(cib->version, IU_CIB_VERSION);
++}
++
++static enum eeprom_validity_state validate_bcb_content(struct interface_configuration_block * bcb) {
++	return compare_versions(bcb->version, IU_BCB_VERSION);
++}
++
++int IU_read_eeprom(void) {
++	int ret = 0;
++	if (eeprom_cib_state != VALID || eeprom_bcb_state != VALID) {
++		ret = read_memory(IU_EEPROM_BUS_NUM, IU_EEPROM_ADDR,
++				IU_BASE_ADDR, (void *) &eeprom, sizeof(eeprom));
++		if (ret) {
++			/* read failed */
++			printf("Interface unit EEPROM content not readable!\n");
++			return 1;
++		} else {
++			/* read successfull */
++			eeprom_cib_state = validate_cib_content(&eeprom.cib);
++			eeprom_bcb_state = validate_bcb_content(&eeprom.bcb);
++			if (eeprom_cib_state == INVALID || eeprom_bcb_state == INVALID) {
++				printf("Interface unit EEPROM content invalid!\n");
++			} else {
++				eeprom_cib_state = VALID;
++				eeprom_bcb_state = VALID;
++			}
++		}
++	}
++	return (eeprom_cib_state != VALID || eeprom_bcb_state != VALID);
++}
++
++int IU_set_mac(const char* ethaddr) {
++	if (!is_valid_ethaddr(eeprom.bcb.mac)) {
++		printf("Interface unit EEPROM does not provide a valid MAC address!\n");
++		return 1;
++	}
++	eth_env_set_enetaddr(ethaddr, eeprom.bcb.mac);
++	return 0;
++}
++
++int IU_get_nfs_boot_flag(void) {
++	return eeprom.bcb.flags.nfs;
++}
++
++void IU_print_eeprom_content(void) {
++	printf("Interface Unit EEPROM Content:\n");
++	printf("  Component Identification Block:\n");
++	printf("\tmagic: %.*s (0x%02x 0x%02x 0x%02x 0x%02x)\n", 4, eeprom.cib.magic,
++			eeprom.cib.magic[0], eeprom.cib.magic[1], eeprom.cib.magic[2], eeprom.cib.magic[3]);
++	printf("\tversion: 0x%02x\n", eeprom.cib.version);
++	printf("\tflags: 0x%02x\n", eeprom.cib.flags);
++	printf("\tcomp_ident: 0x%02x\n", eeprom.cib.comp_ident);
++	printf("\trevision: 0x%02x\n", eeprom.cib.revision);
++	printf("\tserialnr: %02x%02x%02x%02x%02x%02x\n", eeprom.cib.sn[0], eeprom.cib.sn[1],
++			eeprom.cib.sn[2], eeprom.cib.sn[3], eeprom.cib.sn[4], eeprom.cib.sn[5]);
++	printf("  Interface Configuration Block:\n");
++	printf("\tversion: 0x%02x\n", eeprom.bcb.version);
++	printf("\tmacaddr: %02x:%02x:%02x:%02x:%02x:%02x\n", eeprom.bcb.mac[0],
++			eeprom.bcb.mac[1], eeprom.bcb.mac[2], eeprom.bcb.mac[3], eeprom.bcb.mac[4],
++			eeprom.bcb.mac[5]);
++	printf("\tdevicenr: %02x%02x%02x%02x%02x%02x%02x%02x\n", eeprom.bcb.dn[0],
++			eeprom.bcb.dn[1], eeprom.bcb.dn[2], eeprom.bcb.dn[3], eeprom.bcb.dn[4], eeprom.bcb.dn[5],
++			eeprom.bcb.dn[6], eeprom.bcb.dn[7]);
++	printf("\tflags: 0x%02x\n", (uint8_t) * ((uint8_t*) &eeprom.bcb.flags));
++	printf("\t\tnfs: %d\n", eeprom.bcb.flags.nfs);
++	printf("\t\tdhcp: %d\n", eeprom.bcb.flags.dhcp);
++}
+diff --git a/board/freescale/imx8mp_irma6r2/interface_unit.h b/board/freescale/imx8mp_irma6r2/interface_unit.h
+new file mode 100644
+index 0000000000..60ff24b9c5
+--- /dev/null
++++ b/board/freescale/imx8mp_irma6r2/interface_unit.h
+@@ -0,0 +1,24 @@
++#ifndef BOARD_IMX8MP_INTERFACE_UNIT_EEPROM_H_
++#define BOARD_IMX8MP_INTERFACE_UNIT_EEPROM_H_
++
++/*
++ * Read the interface unit EEPROM content to memory and return whether EEPROM was accessible
++ */
++int IU_read_eeprom(void);
++
++/*
++ * Sets the mac address for the given ethernet interface from to the interface unit EEPROM.
++ */
++int IU_set_mac(const char* mac);
++
++/*
++ * Gets the nfs boot flag from the interface unit EEPROM, 1 if booting via nfs, 0 normal boot.
++ */
++int IU_get_nfs_boot_flag(void);
++
++/*
++ * Prints out the interface unit eeprom content
++ */
++void IU_print_eeprom_content(void);
++
++#endif /* BOARD_IMX8MP_INTERFACE_UNIT_EEPROM_H_ */
+-- 
+2.25.1
+

--- a/recipes-bsp/u-boot/u-boot-imx_iris.inc
+++ b/recipes-bsp/u-boot/u-boot-imx_iris.inc
@@ -71,4 +71,6 @@ SRC_URI_append_imx8mp-irma6r2 = "\
 	file://0023-imx8mp-irma6r2-Add-reset-after-bootcmd.patch \
 	file://0024-imx8mp_irma6r2_defconfig-Configure-writeable-list-su.patch \
 	file://0025-imx8mp_irma6r2-Generic-EQOS-driver-dwc_eth_qos.c-usable-for-RMII.patch \
+	file://0026-imx8mp-irma6r2-Add-i2c4-to-bootloader-device-tree-fo.patch \
+	file://0027-imx8mp-irma6r2-Add-IU-EEPROM-readout-for-configuring.patch \
 "


### PR DESCRIPTION
For testing nfs boot write the following value in the IU EEPROM:

**enable nfs boot**
u-boot=> i2c dev 3
u-boot=> i2c mw 51 1F 1 1

**disable nfs boot**
u-boot=> i2c dev 3
u-boot=> i2c mw 51 1F 0 1

MAC address can be tested by comparing the u-boot print out of the EEPROM.

```
Backend EEPROM Content:
  Component Identification Block:
        magic: IRIS (0x49 0x52 0x49 0x53)
        version: 0x01
        flags: 0x00
        comp_ident: 0x02
        revision: 0x03
        serialnr: 9909220003ff
  Backend Configuration Block:
        version: 0x02
        macaddr: 00:24:ea:03:9f:f7   <--- here
        devicenr: 9900000102ffffff
        flags: 0x01
                nfs: 1
                dhcp: 0
```

