### PR TITLE
Feature/migl/rdphoen 618 hwrevision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [APR's Version Numbering](https://apr.apache.org/ver
 - [RDPHOEN-255]: Add Bootloader Update procedure for eMMC with SWUpdate
 - [RDPHOEN-1221]: Applying Iris Coporate Design to SWUpdate webinterface
 - [RDPHOEN-1226]: Adjust EPC660 & Serializer reset pins
+- [RDPHOEN-618]: Unify swupdate hwrevision check
 - [DEVOPS-522]: Add dev keys for swupdate signing, move existing keys from iris-kas repo to meta-iris-base
 - [RDPHOEN-1120]: swupdate: Enable support for signed images
 

--- a/conf/machine/imx8mp-irma6r2.conf
+++ b/conf/machine/imx8mp-irma6r2.conf
@@ -51,3 +51,6 @@ IMX_BOOT_SEEK = "32"
 OPTEE_BIN_EXT = "8mp"
 
 KERNEL_IMAGETYPE_aarch64 = "Image.gz"
+
+# set processor pcb hwrevision for swupdate
+HW_VERSION = "6.2"

--- a/recipes-support/irma6-swuimage/irma6-swuimage.inc
+++ b/recipes-support/irma6-swuimage/irma6-swuimage.inc
@@ -31,7 +31,7 @@ SWU_META = "${IMAGENAME}-${MACHINE}.testdata.json"
 
 SWU_TARGET_FITIMAGE = "fitImage.signed"
 
-SWU_HW_VERSION = "1.0"
+SWU_HW_VERSION ?= "${@'0.0' if not d.getVar('HW_VERSION') else d.getVar('HW_VERSION')}"
 
 # images and files that will be included in the .swu image
 SWUPDATE_IMAGES = "${SWU_FITIMAGE} ${SWU_ROOTFS} ${SWU_BOOTLOADER}"

--- a/recipes-support/swupdate/swupdate_%.bbappend
+++ b/recipes-support/swupdate/swupdate_%.bbappend
@@ -35,6 +35,8 @@ FILES_${PN} += " \
 	${sysconfdir}/swupdate/conf.d/swupdate_default_args \
 "
 
+SWU_HW_VERSION ?= "${@'0.0' if not d.getVar('HW_VERSION') else d.getVar('HW_VERSION')}"
+
 do_install_append () {
 	install -d ${D}${sysconfdir}/init.d
 	install -d ${D}${sysconfdir}/rc5.d
@@ -49,7 +51,10 @@ do_install_append () {
 	install -d ${D}${libdir}/swupdate/lua-handlers
 	install -m 0644 ${WORKDIR}/bootloader_update.lua ${D}${libdir}/swupdate/lua-handlers/
 
-	# all machines are v1.0 for now
+	# set /etc/hwrevision
+	if [ "${SWU_HW_VERSION}" = "0.0" ]; then
+		bbwarn "SWU_HW_VERSION is not set in the machine conf file. Use ${SWU_HW_VERSION} for now!"
+	fi
 	install -d $(basename -- ${D}${SWUPDATE_HW_COMPATIBILITY_FILE})
-	echo "${MACHINE} 1.0" > ${D}${SWUPDATE_HW_COMPATIBILITY_FILE}
+	echo "${MACHINE} ${SWU_HW_VERSION}" > ${D}${SWUPDATE_HW_COMPATIBILITY_FILE}
 }


### PR DESCRIPTION
The HW revision is closely linked to the Yocto MACHINE or the processor board and does not change dynamically at runtime.
SWUpdate (Client) uses the HW revision to check the compatibility of the SWU update package.

Please note: A change in the HW revision for cosmetic reasons (e.g expand it to 3 levels: major.minor.patch) is a breaking change for the update concept!

```
Test:

root@imx8mp-irma6r2:~# cat /etc/hwrevision                                      
imx8mp-irma6r2 6.2

Update positive:
[parse_hw_compatibility] : Accepted Hw Revision : 6.2

Update negative:
[check_hw_compatibility] : Hardware imx8mp-irma6r2 Revision: 6.2
ERROR : SW not compatible with hardware
Image invalid or corrupted. Not installing ...
ERROR : Writing to IPC fails due to Broken pipe
```