### PR TITLE
Feature/migl/rdphoen 618 fw version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [APR's Version Numbering](https://apr.apache.org/ver
 - [RDPHOEN-1221]: Applying Iris Coporate Design to SWUpdate webinterface
 - [RDPHOEN-1226]: Adjust EPC660 & Serializer reset pins
 - [RDPHOEN-618]: Unify swupdate hwrevision check
+- [RDPHOEN-618]: Enable FW Version check for swuimages
 - [DEVOPS-522]: Add dev keys for swupdate signing, move existing keys from iris-kas repo to meta-iris-base
 - [RDPHOEN-1120]: swupdate: Enable support for signed images
 - [RDPHOEN-1120]: swupdate: Enable support for encrypted images

--- a/recipes-support/irma6-swuimage/files/sw-description
+++ b/recipes-support/irma6-swuimage/files/sw-description
@@ -1,6 +1,6 @@
 software =
 {
-    version = "0.1.0";
+    version = "@@SWU_FW_VERSION@@";
     bootloader_transaction_marker = false;
     description = "Firmware update for IRMA6 image";
     hardware-compatibility = [ "@@SWU_HW_VERSION@@" ];

--- a/recipes-support/irma6-swuimage/irma6-swuimage.inc
+++ b/recipes-support/irma6-swuimage/irma6-swuimage.inc
@@ -50,7 +50,13 @@ python do_swuimage_prepend () {
     # read rootfs / irma6 version from meta file
     image_dir = d.getVar('DEPLOY_DIR_IMAGE', True)
     irmameta = json.load(open(os.path.join(image_dir, d.getVar("SWU_META"))))
-    d.setVar("SWU_VERSION_ROOTFS", irmameta['FIRMWARE_VERSION'])
+    fw_version = irmameta['FIRMWARE_VERSION']
+    d.setVar("SWU_VERSION_ROOTFS", fw_version)
+
+    # set the swu fw version
+    import re
+    swu_fw_version = re.search('\d+\.\d+\.\d+', fw_version).group(0)
+    d.setVar("SWU_FW_VERSION", swu_fw_version)
 
     # mark images that needs to be encrypted, before being passed to swu
     def mark_encrypted(artefact):

--- a/recipes-support/swupdate/swupdate/swupdate_default_args
+++ b/recipes-support/swupdate/swupdate/swupdate_default_args
@@ -1,9 +1,16 @@
+# The fw compatibility check in swupdate only compares the version string
+# consisting of major.minor.patch. The image type prefix and also the suffix
+# [-prerelease] or [+buildinfo] are ignored.
+. /etc/os-release
+FW_VERSION=`echo $VERSION | grep -oP '\d+.\d+.\d'`
+
 # -v, --verbose                  : be verbose, set maximum loglevel
 # -p, --postupdate               : execute post-update command
 # -k, --key <public key file>    : file with public key to verify images
 # -K, --key-aes <key file>       : the file contains the symmetric key to be used
 #                                  to decrypt images
-SWUPDATE_ARGS="-v -p 'reboot' -k /etc/iris/ca-certificates/swupdate-ca.crt -K /etc/iris/swupdate/encryption.key"
+# -N, --no-downgrading <version> : not install a release older as <version>
+SWUPDATE_ARGS="-v -p 'reboot' -k /etc/iris/ca-certificates/swupdate-ca.crt -K /etc/iris/swupdate/encryption.key -N $FW_VERSION"
 
 # -p, --port <port>              : server port number  (default: 8080)
 # -r, --document-root <path>     : path to document root directory (default: .)


### PR DESCRIPTION
The FW downgrade is prevented by this feature branch. Reinstalling the firmware (with the same version) is possible. It is still not possible and should not to reinstall the bootloader (with the same version).

**Build**

```
$ bitbake mc:imx8mp-irma6r2:irma6-maintenance-uuu
$ bitbake mc:imx8mp-irma6r2:irma6-maintenance-swuimage
```

**Test: Firmware-Downgrade**

```
For Test 2 & you need to rebuild swuimage with:
kas-irma6-base.yml
18:    IRMA6_DISTRO_VERSION = "2.0.X"
 
 
Test 1: Allow reinstalling the same fw version
$ swupdate -v -k /etc/iris/ca-certificates/swupdate-ca.crt -K /etc/iris/swupdate/encryption.key -w "-r /var/www/swupdate -p 8080" -N 2.0.6
# Try to upload swuimage with same firmware version here: 2.0.6
 
Test 2: Upgrade
$ swupdate -v -k /etc/iris/ca-certificates/swupdate-ca.crt -K /etc/iris/swupdate/encryption.key -w "-r /var/www/swupdate -p 8080" -N 2.0.6
# Try to upload swuimage with greater firmware version here: 2.0.7
 
Test 3: No Downgrading
$ swupdate -v -k /etc/iris/ca-certificates/swupdate-ca.crt -K /etc/iris/swupdate/encryption.key -w "-r /var/www/swupdate -p 8080" -N 2.0.6
# Try to upload swuimage with lesser firmware version here: 2.0.5
[ERROR] : SWUPDATE failed [0] ERROR : No downgrading allowed: new version 2.0.5 <= installed 2.0.6
[ERROR] : SWUPDATE failed [0] ERROR : Compatible SW not found
```