### PR TITLE
Feature/migl/rdphoen 1120 rotate ivt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ and this project adheres to [APR's Version Numbering](https://apr.apache.org/ver
 - [RDPHOEN-1120]: swupdate: Enable support for encrypted images
 - [RDPHOEN-1220]: Add IU EEPROM readout for nfs boot flag
 - [RDPHOEN-1225]: Add IU EEPROM readout for mac address
+- [RDPHOEN-1120]: swupdate: Enable support for rotating iv for encrypted swu images
+
 
 ### Changed
 - [DEVOPS-519] Moved config from iris-kas local.conf to meta-iris-base distro.conf

--- a/recipes-support/irma6-swuimage/files/sw-description
+++ b/recipes-support/irma6-swuimage/files/sw-description
@@ -14,6 +14,7 @@ software =
             version = "$swupdate_get_pkgvar(kernel)";
             properties = {create-destination = "true";};
             sha256 = "$swupdate_get_sha256(@@SWU_FITIMAGE@@)";
+            ivt = "@@SWU_IVT@@";
             encrypted = true;
         },
     );
@@ -24,12 +25,14 @@ software =
             version = "@@SWU_VERSION_ROOTFS@@";
             compressed = "zlib";
             sha256 = "$swupdate_get_sha256(@@SWU_ROOTFS@@)";
+            ivt = "@@SWU_IVT@@";
             encrypted = true;
         },
         {
             filename = "@@SWU_BOOTLOADER_ENV@@";
             type = "bootloader";
             sha256 = "$swupdate_get_sha256(@@SWU_BOOTLOADER_ENV@@)";
+            ivt = "@@SWU_IVT@@";
             encrypted = true;
         },
         {
@@ -39,6 +42,7 @@ software =
             version = "$swupdate_get_pkgvar(@@IMAGE_BOOTLOADER@@)";
             sha256 = "$swupdate_get_sha256(@@SWU_BOOTLOADER@@)";
             install-if-higher = true;
+            ivt = "@@SWU_IVT@@";
             encrypted = true;
         },
     );
@@ -47,6 +51,7 @@ software =
             filename = "@@SWU_PRE_POST_SCRIPT@@";
             type = "shellscript";
             sha256 = "$swupdate_get_sha256(@@SWU_PRE_POST_SCRIPT@@)";
+            ivt = "@@SWU_IVT@@";
             encrypted = true;
         },
     );

--- a/recipes-support/irma6-swuimage/irma6-swuimage.inc
+++ b/recipes-support/irma6-swuimage/irma6-swuimage.inc
@@ -61,6 +61,10 @@ python do_swuimage_prepend () {
     mark_encrypted(d.getVar('SWU_ROOTFS'))
     mark_encrypted(d.getVar('SWU_BOOTLOADER_ENV'))
     mark_encrypted(d.getVar('SWU_PRE_POST_SCRIPT'))
+
+    # The iv is changed with each swu
+    key,iv = swupdate_extract_keys(d.getVar('SWUPDATE_AES_FILE', True))
+    d.setVar("SWU_IVT", iv)
 }
 
 inherit swupdate


### PR DESCRIPTION
The iv can and should be changed with every released update. Change the iv in the 2nd line of dev_keys/swupdate/swupdate_snakeoil_encryption.key for testing purposes. Make sure the update still works with different iv.

**How to create random iv?**
```
$ openssl rand -hex 16
20e39fdb093a57eea0a8a599d7883704
```

**Build**
```
$ bitbake mc:imx8mp-irma6r2:irma6-maintenance-swuimage
```

**Test**
- Build swuimage with different iv (change 2nd line in dev_keys/swupdate/swupdate_snakeoil_encryption.key)
- Check if sw-description has new iv entry
- Make sure update is still possible