### PR TITLE
[DEVOPS-531] Split distro configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [APR's Version Numbering](https://apr.apache.org/ver
 ### Changed
 - [DEVOPS-519] Moved config from iris-kas local.conf to meta-iris-base distro.conf
 - [RDPHOEN-1203]: Change to new mmc-utils repo url for the mmc erase command
+- [DEVOPS-531] Split distro configs into deploy and maintenance
 
 
 ### Deprecated

--- a/conf/distro/poky-iris-common.conf
+++ b/conf/distro/poky-iris-common.conf
@@ -4,7 +4,6 @@
 require conf/distro/poky.conf
 
 DISTRO_VERSION = "${IRMA6_DISTRO_VERSION}"
-DISTRO = "poky-iris"
 DISTRO_NAME = "IRIS IRMA6"
 unset DISTRO_CODENAME
 

--- a/conf/distro/poky-iris-deploy.conf
+++ b/conf/distro/poky-iris-deploy.conf
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2022 iris-GmbH infrared & intelligent sensors
+
+require conf/distro/poky-iris-common.conf
+
+DISTRO = "poky-iris-deploy"

--- a/conf/distro/poky-iris-maintenance.conf
+++ b/conf/distro/poky-iris-maintenance.conf
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2022 iris-GmbH infrared & intelligent sensors
+
+require conf/distro/poky-iris-common.conf
+
+DISTRO = "poky-iris-maintenance"


### PR DESCRIPTION
Split distro config for depoy and maintenance. This is done so that the
maintenance flag can be accessed globaly thoughout the bitbake process.