### PR TITLE
Feature/migl/rdphoen 1250 swupdate post update test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [APR's Version Numbering](https://apr.apache.org/ver
 - [RDPHOEN-1220]: Add IU EEPROM readout for nfs boot flag
 - [RDPHOEN-1225]: Add IU EEPROM readout for mac address
 - [RDPHOEN-1120]: swupdate: Enable support for rotating iv for encrypted swu images
+- [RDPHOEN-1250]: swupdate: Add check if swupdate still runs after update
 - [RDPHOEN-1204]: Add dosfstools to imx8mp irma6-base for formatting with FAT (mkfs.vfat)
 - [RDPHOEN-1204]: Add e2fsprogs-mke2fs to imx8mp irma6-base for formatting with ext4 (mkfs.ext4)
 - [RDPHOEN-1163]: Pregenerate and sign dmverity hashes

--- a/recipes-support/irma6-swuimage/files/pre_post_inst.sh
+++ b/recipes-support/irma6-swuimage/files/pre_post_inst.sh
@@ -4,8 +4,14 @@ if [ $# -lt 1 ]; then
 	exit 0;
 fi
 
+TAG=$0
+
+log() {
+	logger -t $TAG $1
+}
+
 exists() {
-	command -v "$1" >/dev/null 2>&1 || { echo "ERROR: $1 not found"; exit 1; }
+	command -v "$1" >/dev/null 2>&1 || { log "ERROR: $1 not found"; exit 1; }
 }
 
 cmds_exist () {
@@ -22,7 +28,7 @@ parse_cmdline() {
 		# default to update firmware b
 		FIRMWARE_SUFFIX="_b"
 	fi
-	echo "Update firmware${FIRMWARE_SUFFIX}"
+	log "Update firmware${FIRMWARE_SUFFIX}"
 }
 
 set_device_names() {
@@ -63,7 +69,7 @@ get_bootdev_name() {
 	EMMC_DEV="/dev/mmcblk2"
 	KERNEL_DEV=$(sfdisk -J $EMMC_DEV | jq 'first(.partitiontable.partitions[] | select ((.name!=null) and (.name=="linuxboot'${FIRMWARE_SUFFIX}'")) | .node)' -r)
 	if ! [ -b "$KERNEL_DEV" ]; then
-		echo "Could not locate boot partition for firmware${FIRMWARE_SUFFIX}"; exit 1;
+		log "Could not locate boot partition for firmware${FIRMWARE_SUFFIX}"; exit 1;
 	fi
 }
 

--- a/recipes-support/swupdate/swupdate/reset_upgrade_available.sh
+++ b/recipes-support/swupdate/swupdate/reset_upgrade_available.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+TAG=$0
+
+log() {
+	logger -t $TAG $1
+}
+
 # pidofproc()
 . /etc/init.d/functions
 
@@ -8,7 +14,7 @@ PENDING_UPDATE=$(fw_printenv upgrade_available | awk -F'=' '{print $2}')
 if [ "$PENDING_UPDATE" = "1" ]; then
 	# Check if swupdate is still running
 	if ! pidofproc swupdate; then
-		echo "Error: swupdate is not running"
+		log "Error: swupdate is not running"
 		reboot
 		exit 1
 	fi
@@ -18,5 +24,5 @@ if [ "$PENDING_UPDATE" = "1" ]; then
 	printf "bootcount=0\nupgrade_available=\nustate=\n" > "$TMP_ENV_FILE"
 	fw_setenv -s "$TMP_ENV_FILE"
 	rm "$TMP_ENV_FILE"
-	echo "Update successful complete"
+	log "Update successful complete"
 fi

--- a/recipes-support/swupdate/swupdate/reset_upgrade_available.sh
+++ b/recipes-support/swupdate/swupdate/reset_upgrade_available.sh
@@ -1,8 +1,18 @@
 #!/bin/sh
 
-PENDING_UPDATE=$(fw_printenv upgrade_available | awk -F'=' '{print $2}')
+# pidofproc()
+. /etc/init.d/functions
 
+# Check if everything is still ok after update on first boot after reboot
+PENDING_UPDATE=$(fw_printenv upgrade_available | awk -F'=' '{print $2}')
 if [ "$PENDING_UPDATE" = "1" ]; then
+	# Check if swupdate is still running
+	if ! pidofproc swupdate; then
+		echo "Error: swupdate is not running"
+		reboot
+		exit 1
+	fi
+
 	# Use a temp file to write u-boot-env's in one go
 	TMP_ENV_FILE="/tmp/reset_update_envs"
 	printf "bootcount=0\nupgrade_available=\nustate=\n" > "$TMP_ENV_FILE"

--- a/recipes-support/swupdate/swupdate/swupdate_default_args
+++ b/recipes-support/swupdate/swupdate/swupdate_default_args
@@ -3,11 +3,12 @@ FW_VERSION=`echo $VERSION | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'`
 
 # -v, --verbose                  : be verbose, set maximum loglevel
 # -p, --postupdate               : execute post-update command
+# -L, --syslog                   : enable syslog logger
 # -k, --key <public key file>    : file with public key to verify images
 # -K, --key-aes <key file>       : the file contains the symmetric key to be used
 #                                  to decrypt images
 # -N, --no-downgrading <version> : not install a release older as <version>
-SWUPDATE_ARGS="-v -p 'reboot' -k /etc/iris/ca-certificates/swupdate-ca.crt -K /etc/iris/swupdate/encryption.key -N $FW_VERSION"
+SWUPDATE_ARGS="-v -p 'reboot' -k /etc/iris/ca-certificates/swupdate-ca.crt -K /etc/iris/swupdate/encryption.key -N $FW_VERSION -L"
 
 # -p, --port <port>              : server port number  (default: 8080)
 # -r, --document-root <path>     : path to document root directory (default: .)


### PR DESCRIPTION
swupdate: Add check if swupdate still runs after update

```
# 1. Test: Log is written to /var/log/messages
$ fw_setenv upgrade_available 1
$ /etc/init.d/reset_upgrade_available.sh
$ cat /var/log/messages | tail -n 10
[..]
Mar  9 12:36:52 i6-00-24-ea-03-ce-a8 user.notice /etc/init.d/reset_upgrade_available.sh: Update successful complete

# 2. Test: Reboot if swupdate is not running
$ killall swupdate
$ fw_setenv upgrade_available 1
$ /etc/init.d/reset_upgrade_available.sh ; cat /var/log/messages | tail -n 10
[..]
Mar  9 12:41:27 i6-00-24-ea-03-ce-a8 user.notice /etc/init.d/reset_upgrade_available.sh: Error: swupdate is not running
Mar  9 12:41:27 i6-00-24-ea-03-ce-a8 user.notice shutdown[961]: shutting down for system reboot
Mar  9 12:41:27 i6-00-24-ea-03-ce-a8 daemon.info init: Switching to runlevel: 6

# 3. Test: swupdate log to sysroot
- Run swupdate without reboot:
$  /usr/bin/swupdate -v -k /etc/iris/ca-certificates/swupdate-ca.crt -K /etc/iris/swupdate/encryption.key -N 2.0.6 -L -w "-r /var/www/swupdate -p 8080" &

# open an other terminal and verify swupdate writes to syslog 
$ tail -f /var/log/messages
```