### PR TITLE
Feature/phsc/rdphoen 1257 lvm resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ and this project adheres to [APR's Version Numbering](https://apr.apache.org/ver
 - [RDPHOEN-1204]: Add dosfstools to imx8mp irma6-base for formatting with FAT (mkfs.vfat)
 - [RDPHOEN-1204]: Add e2fsprogs-mke2fs to imx8mp irma6-base for formatting with ext4 (mkfs.ext4)
 - [RDPHOEN-1163]: Pregenerate and sign dmverity hashes
-
+- [RDPHOEN-1257]: Add resizing of rootfs logical volume during update
 
 ### Changed
 - [DEVOPS-519] Moved config from iris-kas local.conf to meta-iris-base distro.conf

--- a/recipes-support/irma6-swuimage/files/pre_post_inst.sh
+++ b/recipes-support/irma6-swuimage/files/pre_post_inst.sh
@@ -7,7 +7,7 @@ fi
 TAG=$0
 
 log() {
-	logger -t $TAG $1
+	logger -t "$TAG" "$1"
 }
 
 exists() {

--- a/recipes-support/irma6-swuimage/files/pre_post_inst.sh
+++ b/recipes-support/irma6-swuimage/files/pre_post_inst.sh
@@ -105,10 +105,17 @@ resize_lvm() {
 	export LVM_SUPPRESS_FD_WARNINGS=1
 
 	# get new compressed/encrypted rootfs
-	if [ ! -e /tmp/*.ext4.gz ]; then
+	if [ ! -e /tmp/sw-description ]; then
+		log "Could not find sw-description file during logical volume resize!"; exit 1;
+	fi
+	rootfs_file=$(grep ext4.gz /tmp/sw-description | grep -Eo "\".*\"" | sed 's/"//g')
+	if [ -z "$rootfs_file" ]; then
 		log "Could not find new rootfs during logical volume resize!"; exit 1;
 	fi
-	rootfs_file=$(ls /tmp/*.ext4.gz)
+	rootfs_file="/tmp/$rootfs_file"
+	if [ ! -e "$rootfs_file" ]; then
+		log "Could not find new rootfs during logical volume resize!"; exit 1;
+	fi
 
 	# get encryption key for decrypting
 	key=$(cut -d' ' -f1 < /etc/iris/swupdate/encryption.key)

--- a/recipes-support/irma6-swuimage/files/pre_post_inst.sh
+++ b/recipes-support/irma6-swuimage/files/pre_post_inst.sh
@@ -120,12 +120,17 @@ resize_lvm() {
 	if [ $new_size -ne $cur_size ]; then
 
 		# mount over read-only /etc/lvm to modify config
-		mkdir -p /tmp/etc/lvm
-		mount --bind /tmp/etc/lvm /etc/lvm
+		if ! grep -qs /etc/lvm /proc/mounts; then
+			mkdir -p /tmp/etc/lvm
+			mount --bind /tmp/etc/lvm /etc/lvm
+		fi
 
 		echo "Resize rootfs logical volume: ${cur_size} -> ${new_size}"
 		lvresize --force --yes --quiet -L "$new_size"B "$ROOT_DEV" 2> /dev/null
 		vgmknodes
+
+		umount /etc/lvm
+		rm -R /tmp/etc
 	fi
 }
 


### PR DESCRIPTION
## Test increase logical volume size
mount over config to configure lvm
`mkdir -p /tmp/etc/lvm; mount --bind /tmp/etc/lvm /etc/lvm`
see which firmware is booted
`lsblk`
resize firmware lv that is not booted
`lvresize --force --yes --quiet -L 50MB /dev/mapper/irma6lvm-rootfs_b`
trigger swupdate
```
[read_lines_notify] : Resize rootfs logical volume: 54525952 -> 75942912
[read_lines_notify] : Rounding size to boundary between physical extents: 76.00 MiB.
[read_lines_notify] : Size of logical volume irma6lvm/rootfs_b changed from 52.00 MiB (13 extents) to 76.00 MiB (19 extents).
[read_lines_notify] : Logical volume irma6lvm/rootfs_b successfully resized.
```
## Test decrease logical volume size
mount over config to configure lvm
`mkdir -p /tmp/etc/lvm; mount --bind /tmp/etc/lvm /etc/lvm`
see which firmware is booted
`lsblk`
resize firmware lv that is not booted
`lvresize --force --yes --quiet -L 100MB /dev/mapper/irma6lvm-rootfs_a`
trigger swupdate
```
[read_lines_notify] : Resize rootfs logical volume: 104857600 -> 75942912
[read_lines_notify] : Rounding size to boundary between physical extents: 76.00 MiB.
[read_lines_notify] : Size of logical volume irma6lvm/rootfs_b changed from 100.00 MiB (25 extents) to 76.00 MiB (19 extents).
[read_lines_notify] : Logical volume irma6lvm/rootfs_b successfully resized.
```
## Test same logical volume size

just trigger swupdate without any modifications. No lv resizing should take place.
```
[read_lines_notify] : Resize rootfs logical volume: 79691776 -> 75942912
[read_lines_notify] : Rounding size to boundary between physical extents: 76.00 MiB.
```