### PR TITLE
[RDPHOEN-1228] swupdate check SRK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [APR's Version Numbering](https://apr.apache.org/ver
 - [RDPHOEN-1084]: Add config fragment for kernel and u-boot
 - [RDPHOEN-1273]: Add encryption of logical volumes to initramfs to use valid black key blobs
 - [RDPHOEN-1270]: Add check for when the device is locked to not nfs boot
+- [RDPHOEN-1228]: Add SRK bootloader check for secure boot activated devices
 
 ### Changed
 - [DEVOPS-519] Moved config from iris-kas local.conf to meta-iris-base distro.conf

--- a/recipes-core/images/irma6-base.bb
+++ b/recipes-core/images/irma6-base.bb
@@ -41,6 +41,7 @@ IRMA6_EXTRA_PACKAGES = " \
 	rsyslog \
 	chrony \
 	chronyc \
+	hab-csf-parser \
 "
 # IRMA6R2 SoC specific packages (not included in qemu)
 IRMA6_EXTRA_PACKAGES_append_mx8mp = " \

--- a/recipes-core/images/irma6-base.bb
+++ b/recipes-core/images/irma6-base.bb
@@ -42,6 +42,7 @@ IRMA6_EXTRA_PACKAGES = " \
 	chrony \
 	chronyc \
 	hab-csf-parser \
+	hab-srktool-scripts \
 "
 # IRMA6R2 SoC specific packages (not included in qemu)
 IRMA6_EXTRA_PACKAGES_append_mx8mp = " \

--- a/recipes-support/cst/files/0001-Makefile-Enable-cross-compilation.patch
+++ b/recipes-support/cst/files/0001-Makefile-Enable-cross-compilation.patch
@@ -1,0 +1,44 @@
+From cf25799a0db3836a94677ecdfebec5eaea196c62 Mon Sep 17 00:00:00 2001
+From: Ian Dannapel <ian.dannapel@iris-sensing.com>
+Date: Tue, 2 Aug 2022 09:28:39 +0200
+Subject: [PATCH] Makefile: Enable cross compilation
+
+---
+ Makefile     | 6 +++---
+ csf_parser.c | 2 +-
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index ef88b66..9095f23 100755
+--- a/Makefile
++++ b/Makefile
+@@ -10,10 +10,10 @@
+ #
+ #==============================================================================
+ 
+-CC = gcc
++CC ?= gcc
+ 
+-COPTS = -g -Wall -Werror
+-CFLAGS = -I.
++COPTS ?= -g -Wall -Werror
++CFLAGS ?= -I.
+ 
+ DEPS = csf_parser.h extract_csf.h
+ SRCS = csf_parser.c extract_csf.c
+diff --git a/csf_parser.c b/csf_parser.c
+index c72fc6d..810607e 100755
+--- a/csf_parser.c
++++ b/csf_parser.c
+@@ -477,7 +477,7 @@ int parse_unlock_cmd(const uint8_t *csf_hdr, int csf_len, int offset)
+ 
+         char *def = NULL;
+         char *des = NULL;
+-        uint32_t ulck_features;
++        uint32_t ulck_features = 0;
+         csf_cmd_unlock_t *unlock_cmd = (csf_cmd_unlock_t *)csf_hdr;
+ 
+         if (debug_log) {
+-- 
+2.25.1
+

--- a/recipes-support/cst/files/0001-createSRKFuses-add-ecc-keys.patch
+++ b/recipes-support/cst/files/0001-createSRKFuses-add-ecc-keys.patch
@@ -1,0 +1,169 @@
+From 6f3bd4d043b25e19ad90c3a104cae71beaef16b1 Mon Sep 17 00:00:00 2001
+From: Ian Dannapel <ian.dannapel@iris-sensing.com>
+Date: Tue, 2 Aug 2022 16:19:22 +0200
+Subject: [PATCH] createSRKFuses: add ecc keys
+
+---
+ createSRKFuses | 93 +++++++++++++++++++++++++++++---------------------
+ 1 file changed, 54 insertions(+), 39 deletions(-)
+
+diff --git a/createSRKFuses b/createSRKFuses
+index d8cbe65..1a47f31 100755
+--- a/createSRKFuses
++++ b/createSRKFuses
+@@ -1,8 +1,8 @@
++#!/bin/bash
+ #
+-# Copyright 2017-2018 NXP
++# Copyright 2017-2018, 2022 NXP
+ #
+ ##########################################################################
+-#!/bin/bash
+ #
+ # SCRIPT:  	createSRKFuses
+ #
+@@ -17,14 +17,21 @@
+ #Debug
+ DEBUG=0
+ 
+-# Help
+-if [[ "$1" = "-h" || "$1" = "--help" || "$1" = "" ]] ; then
+-	echo
+-	echo "./createSRKFuses [-h|--help] for help"
+-	echo "Usage: ./createSRKFuses <SRK table> <Number of SRKs> <SRK key length>"
+-	echo "Number of SRK : 1 - 4"
+-	echo "SRK Key Length : 1024, 2048, 3072, 4096"
++print_usage ()
++{
++    echo
++    echo "./createSRKFuses [-h|--help] for help"
++    echo "Usage: ./createSRKFuses <SRK table> <Number of SRKs> <SRK key length> <SRK Key Type>"
++    echo "Number of SRK : 1 - 4"
++	echo "SRK Key Type : rsa, ecc"
++    echo "SRK Key Length : 1024, 2048, 3072, 4096 for RSA key type"
++	echo "                 256, 384 or 521 for ECC key type"
+ 	exit 1
++}
++
++# Help
++if [[ "$1" == "-h" || "$1" == "--help" || "$1" == "" ]] ; then
++	print_usage
+ fi
+ 
+ # Input SRK Table file
+@@ -33,12 +40,7 @@ if [[ -n "$SRKtablefile" &&  -f "$SRKtablefile" ]] ; then
+ 	echo "SRK table file is $1"
+ else
+ 	echo "File $1 doesnt exist or is empty"
+-	echo
+-	echo "./createSRKFuses [-h|--help] for help"
+-	echo "Usage: ./createSRKFuses <SRK table> <Number of SRKs> <SRK key length>"
+-	echo "Number of SRK : 1 - 4"
+-	echo "SRK Key Length : 1024, 2048, 3072, 4096"
+-	exit 1
++	print_usage
+ fi
+ 
+ # Number of SRK certs
+@@ -47,37 +49,50 @@ if [[ $2 > 0 && $2 < 5 ]] ; then
+ 	echo "Number of SRKs are $nSRK"
+ else
+ 	echo "Number of SRKs need to be between 1 and 4"
+-	echo
+-	echo "./createSRKFuses [-h|--help] for help"
+-	echo "Usage: ./createSRKFuses <SRK table> <Number of SRKs> <SRK key length>"
+-	echo "Number of SRK : 1 - 4"
+-	echo "SRK Key Length : 1024, 2048, 3072, 4096"
+-	exit 1
++	print_usage
+ fi
+ 
+-# SRK key length
+-lSRK=$3
+-if [[ $lSRK = 1024 || $lSRK = 2048 || $lSRK = 3072 || $lSRK = 4096 ]] ; then
+-	echo "SRK Key length is $lSRK"
++# SRK key type
++tSRK=$4
++if [[ $tSRK == "rsa" || $tSRK == "ecc" ]] ; then
++	echo "SRK Key Type is $4"
++	# SRK key length based on key type
++	lSRK=$3
++	if [[ $tSRK == "rsa" ]] ; then
++		if [[ $lSRK == 1024 || $lSRK == 2048 || $lSRK == 3072 || $lSRK == 4096 ]] ; then
++			echo "SRK $tSRK Key length is $lSRK"
++		else
++			echo "SRK key length needs to be 1024, 2048, 3072 or 4096 bits"
++			print_usage
++		fi
++	else
++		if [[ $lSRK == 256 || $lSRK == 384 || $lSRK == 521 ]] ; then
++			echo "SRK $tSRK Key length is $lSRK"
++		else
++			echo "SRK key length needs to be 256, 384 or 521 bits"
++			print_usage
++		fi
++	fi
+ else
+-	echo "SRK key length needs to be 1024, 2048, 3072 or 4096 bits"
+-	echo
+-	echo "./createSRKFuses [-h|--help] for help"
+-	echo "Usage: ./createSRKFuses <SRK table> <Number of SRKs> <SRK key length>"
+-	echo "Number of SRK : 1 - 4"
+-	echo "SRK Key Length : 1024, 2048, 3072, 4096"
+-	exit 1
++	echo "SRK Key type should be rsa or ecc"
++	print_usage
+ fi
+ 
+ # Decide size of cert w.r.t SRK Key Length
+-if [ $lSRK = 1024 ] ; then
++if [ $lSRK == 1024 ] ; then
+ 	countSize=143;
+-elif [ $lSRK = 2048 ] ; then
++elif [ $lSRK == 2048 ] ; then
+ 	countSize=271;
+-elif [ $lSRK = 3072 ] ; then
++elif [ $lSRK == 3072 ] ; then
+ 	countSize=399;
+-elif [ $lSRK = 4096 ] ; then
++elif [ $lSRK == 4096 ] ; then
+ 	countSize=527;
++elif [ $lSRK == 256 ] ; then
++	countSize=76
++elif [ $lSRK == 384 ] ; then
++    countSize=108
++elif [ $lSRK == 521 ] ; then
++    countSize=144
+ fi
+ 
+ 
+@@ -86,7 +101,7 @@ i=$nSRK
+ for nSRK in {1..4} ; do
+ 	dd if=$1 of=SRKCert$nSRK bs=1 skip=$((4+($countSize*($nSRK-1)))) count=$countSize
+ 	echo "File SRKCert$nSRK created"
+-	if [ $nSRK = $i ] ; then
++	if [ $nSRK == $i ] ; then
+ 		break
+ 	fi
+ done
+@@ -99,7 +114,7 @@ for fSRK in SRKCert[1234] ; do
+ 			perl -e 'print pack "H*", <STDIN>' | \
+ 				dd of=$fSRK.bin bs=1 count=32
+ 	echo "File $fSRK.bin created"
+-	if [ $nSRK = $i ] ; then
++	if [ $nSRK == $i ] ; then
+ 		break
+ 	fi
+ 	i=$((i+1))
+@@ -112,7 +127,7 @@ cat SRKCert[1234].bin | \
+ 			dd of=SRK_fuses.bin bs=1 count=32
+ 
+ #remove all temp files
+-if [ $DEBUG = 0 ]; then
++if [ $DEBUG == 0 ]; then
+ 	rm -v SRKCert*
+ fi
+ 
+-- 
+2.25.1
+

--- a/recipes-support/cst/hab-csf-parser_3.3.1.bb
+++ b/recipes-support/cst/hab-csf-parser_3.3.1.bb
@@ -1,0 +1,20 @@
+DESCRIPTION = "CSF Parsing Tool for NXP's High Assurance Boot with i.MX processors."
+AUTHOR = "NXP"
+HOMEPAGE = "http://www.nxp.com"
+LICENSE = "CLOSED"
+
+FILES_${PN} += "${bindir}/csf_parser"
+
+SRC_URI = "https://iris-devops-imx-cst-public-693612562064.s3.eu-central-1.amazonaws.com/cst-${PV}.tgz \
+    file://0001-Makefile-Enable-cross-compilation.patch;patchdir=${WORKDIR}/cst-${PV}/code/hab_csf_parser \
+"
+SRC_URI[sha256sum] = "1efdddda50cf36bc1e48d78a9601ba33db0cc2203ff1086c4b373f94b9366464"
+
+S = "${WORKDIR}/cst-${PV}/code/hab_csf_parser"
+
+TARGET_CC_ARCH += "${LDFLAGS}"
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 ${S}/csf_parser ${D}${bindir}
+}

--- a/recipes-support/cst/hab-srktool-scripts_3.3.1.bb
+++ b/recipes-support/cst/hab-srktool-scripts_3.3.1.bb
@@ -1,0 +1,24 @@
+DESCRIPTION = "SRK Tool scripts for NXP's High Assurance Boot with i.MX processors."
+AUTHOR = "NXP"
+HOMEPAGE = "http://www.nxp.com"
+LICENSE = "CLOSED"
+
+FILES_${PN} += " \
+    ${bindir}/createSRKFuses \
+    ${bindir}/createSRKTable \
+    "
+
+SRC_URI = "https://iris-devops-imx-cst-public-693612562064.s3.eu-central-1.amazonaws.com/cst-${PV}.tgz \
+    file://0001-createSRKFuses-add-ecc-keys.patch;patchdir=${WORKDIR}/cst-${PV}/code/hab_srktool_scripts \
+"
+SRC_URI[sha256sum] = "1efdddda50cf36bc1e48d78a9601ba33db0cc2203ff1086c4b373f94b9366464"
+
+
+S = "${WORKDIR}/cst-${PV}/code/hab_srktool_scripts"
+RDEPENDS_${PN} += "bash perl"
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 ${S}/createSRKFuses ${D}${bindir}
+    install -m 0755 ${S}/createSRKTable ${D}${bindir}
+}


### PR DESCRIPTION
#### Avoids an update if the bootloader SRKs do not match the current SRKs burned in the fuses.
Firmware: [Gitlab](https://gitlab.devops.defra01.iris-sensing.net/MIRROR/iris-kas/-/pipelines/1691) 
to do: include SRK revocation: [RDPHOEN-1278](https://jira.iris-sensing.net/browse/RDPHOEN-1278)

Test 1 - Without secure boot active, SRKs are not checked:
```
Secure boot is not activated, skipping SRK fuses verification
```
Test 2 - Board with secure boot active and matching uboot:
```
SRK Bootloader verification passed
```
Test 3 - Board with secure boot active and not matching uboot:
```
Aborting, SRK Bootloader does not match SRK Fuse!
SRK Bootloader: 0x3b8ad329
...
SRK Fuse: 0x96ed4c5c
...
```

 

