### PR TITLE
Feature/phsc/rdphoen 1177 debug tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ and this project adheres to [APR's Version Numbering](https://apr.apache.org/ver
 - [DEVOPS-519] Moved config from iris-kas local.conf to meta-iris-base distro.conf
 - [RDPHOEN-1203]: Change to new mmc-utils repo url for the mmc erase command
 - [DEVOPS-531] Split distro configs into deploy and maintenance
-
+- [RDPHOEN-1257]: Changed to only enable debug-tweaks for maintenance build
 
 ### Deprecated
 

--- a/conf/distro/poky-iris-common.conf
+++ b/conf/distro/poky-iris-common.conf
@@ -54,7 +54,4 @@ ROOTHASH_DM_VERITY_SALT ?= "${SIGNING_KEYS_DIR}/roothash.salt"
 
 IMAGE_FEATURES += "read-only-rootfs"
 
-# FIXME [RDPHOEN-1177]: This needs to be disabled for security reasons in Rel2
-IMAGE_FEATURES += "debug-tweaks"
-
 PREFERRED_VERSION_chrony = "4.2"

--- a/conf/distro/poky-iris-maintenance.conf
+++ b/conf/distro/poky-iris-maintenance.conf
@@ -4,3 +4,5 @@
 require conf/distro/poky-iris-common.conf
 
 DISTRO = "poky-iris-maintenance"
+
+IMAGE_FEATURES += "debug-tweaks"


### PR DESCRIPTION
Disables root login in deploy firmware.

Tests:
1. Flash maintenance firmware and check if you can still login as root via uart console or ssh
2. Flash deploy firmware and check if you can NOT login as root via uart console or ssh