### PR TITLE
Feature/phsc/rdphoen 1084 distro config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ and this project adheres to [APR's Version Numbering](https://apr.apache.org/ver
 - [DEVOPS-519] Moved config from iris-kas local.conf to meta-iris-base distro.conf
 - [RDPHOEN-1203]: Change to new mmc-utils repo url for the mmc erase command
 - [DEVOPS-531] Split distro configs into deploy and maintenance
-
+- [RDPHOEN-1257]: Changed to only enable debug-tweaks for maintenance build
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,12 +58,14 @@ and this project adheres to [APR's Version Numbering](https://apr.apache.org/ver
 - [APC-4836]: Add chrony integration for IRMA 6 R2.
 - [APC-4836] Disable internal snvs rtc on r2.
 - [RDPHOEN-1040]: Add "sync" command in uuu flash script
+- [RDPHOEN-1084]: Add config fragment for kernel and u-boot
 
 ### Changed
 - [DEVOPS-519] Moved config from iris-kas local.conf to meta-iris-base distro.conf
 - [RDPHOEN-1203]: Change to new mmc-utils repo url for the mmc erase command
 - [DEVOPS-531] Split distro configs into deploy and maintenance
 - [RDPHOEN-1257]: Changed to only enable debug-tweaks for maintenance build
+- [RDPHOEN-1152]: Disable u-boot console and boot delay for deploy build
 
 ### Deprecated
 

--- a/conf/distro/poky-iris-common.conf
+++ b/conf/distro/poky-iris-common.conf
@@ -54,7 +54,4 @@ ROOTHASH_DM_VERITY_SALT ?= "${SIGNING_KEYS_DIR}/roothash.salt"
 
 IMAGE_FEATURES += "read-only-rootfs"
 
-# FIXME [RDPHOEN-1177]: This needs to be disabled for security reasons in Rel2
-IMAGE_FEATURES += "debug-tweaks"
-
 PREFERRED_VERSION_chrony = "4.2"

--- a/conf/distro/poky-iris-maintenance.conf
+++ b/conf/distro/poky-iris-maintenance.conf
@@ -4,3 +4,5 @@
 require conf/distro/poky-iris-common.conf
 
 DISTRO = "poky-iris-maintenance"
+
+IMAGE_FEATURES += "debug-tweaks"

--- a/recipes-bsp/u-boot/u-boot-imx/common/deploy-u.cfg
+++ b/recipes-bsp/u-boot/u-boot-imx/common/deploy-u.cfg
@@ -1,0 +1,1 @@
+# deploy config fragment for u-boot

--- a/recipes-bsp/u-boot/u-boot-imx/common/deploy-u.cfg
+++ b/recipes-bsp/u-boot/u-boot-imx/common/deploy-u.cfg
@@ -1,1 +1,2 @@
 # deploy config fragment for u-boot
+CONFIG_BOOTDELAY=-2

--- a/recipes-bsp/u-boot/u-boot-imx_iris.inc
+++ b/recipes-bsp/u-boot/u-boot-imx_iris.inc
@@ -74,3 +74,7 @@ SRC_URI_append_imx8mp-irma6r2 = "\
 	file://0026-imx8mp-irma6r2-Add-i2c4-to-bootloader-device-tree-fo.patch \
 	file://0027-imx8mp-irma6r2-Add-IU-EEPROM-readout-for-configuring.patch \
 "
+
+SRC_URI_append_poky-iris-deploy = "\
+	file://deploy-u.cfg \
+"

--- a/recipes-kernel/linux/linux-fslc-iris.inc
+++ b/recipes-kernel/linux/linux-fslc-iris.inc
@@ -44,6 +44,10 @@ SRC_URI += " \
     file://0036-imx8mp-irma6r2.dts-Adjust-EPC660-TC358746-reset-pins.patch \
 "
 
+SRC_URI_append_poky-iris-deploy = "\
+	file://deploy.cfg \
+"
+
 KERNEL_DEFCONFIG_imx8mpevk = "imx8mp-evk-r2_defconfig"
 KERNEL_DEFCONFIG_imx8mp-irma6r2 = "imx8mp_irma6r2_defconfig"
 

--- a/recipes-kernel/linux/linux-fslc-iris/deploy.cfg
+++ b/recipes-kernel/linux/linux-fslc-iris/deploy.cfg
@@ -1,0 +1,1 @@
+# deploy config fragment for kernel


### PR DESCRIPTION
Merge after https://github.com/iris-GmbH/meta-iris-base/pull/137

Tests
1. flash maintenance firmware and get into u-boot shell before timeout.
2. flash develop firmware and try to get into u-boot shell which will not work, root login in linux will also not work because debug-tweaks was removed.
