### PR TITLE
[RDPHOEN-1040] Adding the uuu-sync command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [APR's Version Numbering](https://apr.apache.org/ver
 - [APC-4848]: Add rsyslog integration for IRMA 6 R2.
 - [APC-4836]: Add chrony integration for IRMA 6 R2.
 - [APC-4836] Disable internal snvs rtc on r2.
+- [RDPHOEN-1040]: Add "sync" command in uuu flash script
 
 ### Changed
 - [DEVOPS-519] Moved config from iris-kas local.conf to meta-iris-base distro.conf

--- a/recipes-bsp/irma6-uuu/files/flashall_imx8mp.uuu
+++ b/recipes-bsp/irma6-uuu/files/flashall_imx8mp.uuu
@@ -91,18 +91,22 @@ FBK: ucmd vgmknodes
 # Flash rootfs to both rootfs partitions
 FBK: acmd zcat | dd of=/dev/mapper/decrypted-irma6lvm-rootfs_a
 FBK: ucp rootfs.ext4.gz t:-
+FBK: sync
 FBK: ucmd sync
 
 FBK: acmd zcat | dd of=/dev/mapper/decrypted-irma6lvm-rootfs_b
 FBK: ucp rootfs.ext4.gz t:-
+FBK: sync
 FBK: ucmd sync
 
 FBK: acmd cat | dd of=/dev/mapper/irma6lvm-rootfs_a_hash
 FBK: ucp rootfs.ext4.hashdevice t:-
+FBK: sync
 FBK: ucmd sync
 
 FBK: acmd cat | dd of=/dev/mapper/irma6lvm-rootfs_b_hash
 FBK: ucp rootfs.ext4.hashdevice t:-
+FBK: sync
 FBK: ucmd sync
 
 # Create ext4 partition for userdata


### PR DESCRIPTION
as "ucmd sync" waits only on linux level, and
"sync" already waits in uuu tool for dd being ready with copying
(see uuu manual "Example for transfer big file")