### PR TITLE
Feature/phsc/rdphoen 1270 disable nfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [APR's Version Numbering](https://apr.apache.org/ver
 - [RDPHOEN-1040]: Add "sync" command in uuu flash script
 - [RDPHOEN-1084]: Add config fragment for kernel and u-boot
 - [RDPHOEN-1273]: Add encryption of logical volumes to initramfs to use valid black key blobs
+- [RDPHOEN-1270]: Add check for when the device is locked to not nfs boot
 
 ### Changed
 - [DEVOPS-519] Moved config from iris-kas local.conf to meta-iris-base distro.conf

--- a/recipes-bsp/u-boot/u-boot-imx/imx8mp-irma6r2/0028-imx8mp-irma6r2-Add-check-for-when-the-device-is-lock.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/imx8mp-irma6r2/0028-imx8mp-irma6r2-Add-check-for-when-the-device-is-lock.patch
@@ -1,0 +1,56 @@
+From 2031147dd87254fd84a224c564b33a1253a2f7e9 Mon Sep 17 00:00:00 2001
+From: "philipp.schoewe" <Philipp.Schoewe@iris-sensing.com>
+Date: Tue, 16 Aug 2022 08:41:20 +0200
+Subject: [PATCH 1/1] imx8mp-irma6r2: Add check for when the device is locked
+ to not nfs boot
+
+Signed-off-by: philipp.schoewe <Philipp.Schoewe@iris-sensing.com>
+---
+ board/freescale/imx8mp_irma6r2/imx8mp_irma6r2.c | 17 ++++++++++++++++-
+ 1 file changed, 16 insertions(+), 1 deletion(-)
+
+diff --git a/board/freescale/imx8mp_irma6r2/imx8mp_irma6r2.c b/board/freescale/imx8mp_irma6r2/imx8mp_irma6r2.c
+index 6b5d01c4b7..b3c2c271d6 100644
+--- a/board/freescale/imx8mp_irma6r2/imx8mp_irma6r2.c
++++ b/board/freescale/imx8mp_irma6r2/imx8mp_irma6r2.c
+@@ -25,6 +25,7 @@
+ #include <mmc.h>
+ #include "bootcount.h"
+ #include "interface_unit.h"
++#include <fuse.h>
+ 
+ DECLARE_GLOBAL_DATA_PTR;
+ 
+@@ -519,6 +520,16 @@ int board_init(void)
+ 	return 0;
+ }
+ 
++int security_fuse_burned(void)
++{
++	u32 fuse_word = 0;
++	// 0x470 (bank 1, word 3) bit 25 = SEC_CONFIG[1] - Closed (Security On)
++	if (fuse_sense(1, 3, &fuse_word) != 0) {
++		fuse_word = 1; // in case of corrupt fuse box do not allow nfs boot
++	}
++	return (fuse_word & 0x02000000); // 0x02000000 = Bit 25
++}
++
+ void board_autogenerate_bootcmd (void)
+ {
+     int firmware_env = env_get_ulong("firmware", 10, 0);
+@@ -582,7 +593,11 @@ void board_autogenerate_bootcmd (void)
+ 	if (IU_read_eeprom() == 0) {
+ 		IU_print_eeprom_content();
+ 		IU_set_mac("eth1addr");
+-		nfs_boot = IU_get_nfs_boot_flag();
++
++		/* check if device is unlocked and allowed to nfs boot */
++		if (security_fuse_burned() == 0) { 
++			nfs_boot = IU_get_nfs_boot_flag();
++		}
+ 	}
+ 	
+ 	if (nfs_boot) {
+-- 
+2.25.1
+

--- a/recipes-bsp/u-boot/u-boot-imx_iris.inc
+++ b/recipes-bsp/u-boot/u-boot-imx_iris.inc
@@ -73,6 +73,7 @@ SRC_URI_append_imx8mp-irma6r2 = "\
 	file://0025-imx8mp_irma6r2-Generic-EQOS-driver-dwc_eth_qos.c-usable-for-RMII.patch \
 	file://0026-imx8mp-irma6r2-Add-i2c4-to-bootloader-device-tree-fo.patch \
 	file://0027-imx8mp-irma6r2-Add-IU-EEPROM-readout-for-configuring.patch \
+	file://0028-imx8mp-irma6r2-Add-check-for-when-the-device-is-lock.patch \
 "
 
 SRC_URI_append_poky-iris-deploy = "\


### PR DESCRIPTION
Enable NFS boot on interface unit
u-boot=> i2c dev 3
u-boot=> i2c mw 51 1F 1 1

1. Test sensor unit with security lock - Will **NOT** NFS boot
2. Test sensor unit without security lock - Will NFS boot