### PR TITLE
Feature/ersc/rdphoen 1295 thermal fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ and this project adheres to [APR's Version Numbering](https://apr.apache.org/ver
 - [DEVOPS-531] Split distro configs into deploy and maintenance
 - [RDPHOEN-1257]: Changed to only enable debug-tweaks for maintenance build
 - [RDPHOEN-1152]: Disable u-boot console and boot delay for deploy build
+- [RDPHOEN-1295]: Increase critical CPU temperature for R2 to 105 degree celsius
 
 ### Deprecated
 

--- a/recipes-kernel/linux/linux-fslc-iris.inc
+++ b/recipes-kernel/linux/linux-fslc-iris.inc
@@ -42,6 +42,7 @@ SRC_URI += " \
     file://0034-imx8mp-irma6r2.dts-Add-kernel-driver-for-eth0-ADIn1200-PHY.patch \
     file://0035-RDPHOEN-1218-Skip-registering-of-clkout-for-RTC.patch \
     file://0036-imx8mp-irma6r2.dts-Adjust-EPC660-TC358746-reset-pins.patch \
+    file://0037-RDPHOEN-1295-Increase-critical-thermal-point.patch \
 "
 
 SRC_URI_append_poky-iris-deploy = "\

--- a/recipes-kernel/linux/linux-fslc-iris/0037-RDPHOEN-1295-Increase-critical-thermal-point.patch
+++ b/recipes-kernel/linux/linux-fslc-iris/0037-RDPHOEN-1295-Increase-critical-thermal-point.patch
@@ -1,0 +1,44 @@
+From 604f1d6be2bdceeadbb03c9af8006d2516f2fca7 Mon Sep 17 00:00:00 2001
+From: Erik Schumacher <erik.schumacher@iris-sensing.com>
+Date: Thu, 18 Aug 2022 16:47:57 +0200
+Subject: [PATCH] [RDPHOEN-1295] Increase critical thermal point
+
+Industrial version of SoC can handle 105 degree celsius
+
+Signed-off-by: Erik Schumacher <erik.schumacher@iris-sensing.com>
+---
+ .../boot/dts/freescale/imx8mp-irma6r2.dts      | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/freescale/imx8mp-irma6r2.dts b/arch/arm64/boot/dts/freescale/imx8mp-irma6r2.dts
+index dbc04bb7914f..0d2c28ec6d9e 100644
+--- a/arch/arm64/boot/dts/freescale/imx8mp-irma6r2.dts
++++ b/arch/arm64/boot/dts/freescale/imx8mp-irma6r2.dts
+@@ -96,6 +96,24 @@
+ 	};
+ };
+ 
++/* IRMA6R2 uses the industrial version so we can handle 105 degree celsius
++   Be careful when using consumer grade CPUs for development! */
++&cpu_alert0 {
++	temperature = <95000>;
++};
++
++&cpu_crit0 {
++	temperature = <105000>;
++};
++
++&soc_alert0 {
++	temperature = <95000>;
++};
++
++&soc_crit0 {
++	temperature = <105000>;
++};
++
+ &dsp_reserved {
+ 	reg = <0 0x5C000000 0 0x2000000>;
+ };
+-- 
+2.37.2
+


### PR DESCRIPTION
Increase critical temperate to 105°C. The kernel will automatically shutdown if this temperature is reached.

Read out with:
```
# cat /sys/class/thermal/thermal_zone*/trip_point*temp
85000
105000   # critical temperature, was 95000 = 95°C before
85000
105000   # critical temperature, was 95000 = 95°C before
```

Current temperature can be read with:
```
# cat /sys/class/thermal/thermal_zone*/temp 
44000
44000
```

You can also write a custom critical trip point to the file to simulate an automatic shutdown:
```
# echo 49000 > /sys/class/thermal/thermal_zone0/trip_point_1_temp                                   
# echo 49000 > /sys/class/thermal/thermal_zone1/trip_point_1_temp
# cat /dev/urandom > /dev/null & # create some load
[1] 851
# cat /dev/urandom > /dev/null &
[2] 852
root@imx8mp-irma6r2:~# [ 1710.913275] thermal thermal_zone1: critical temperature reached (49 C), shutting down
[...]
The system is going down for system halt NOW!
```