### PR TITLE
[RDPHOEN-1291] Increase pwm2 for serializer to over 24MHz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [APR's Version Numbering](https://apr.apache.org/ver
 - [RDPHOEN-1257]: Changed to only enable debug-tweaks for maintenance build
 - [RDPHOEN-1152]: Disable u-boot console and boot delay for deploy build
 - [RDPHOEN-1295]: Increase critical CPU temperature for R2 to 105 degree celsius
+- [RDPHOEN-1291]: Set pwm2 for serializer on R2 to a frequency slightly above 24 MHz
 
 ### Deprecated
 

--- a/recipes-kernel/linux/linux-fslc-iris/0020-imx8mp-irma6r2.dts-Replace-dummy-clock-for-serialize.patch
+++ b/recipes-kernel/linux/linux-fslc-iris/0020-imx8mp-irma6r2.dts-Replace-dummy-clock-for-serialize.patch
@@ -24,9 +24,9 @@ index c3310e458ed6..6efd0e80c894 100644
  		#clock-cells = <0>;
 -		clock-frequency = <32000000>;
 -		clock-output-names = "32m_serialize";
-+		clock-frequency = <24000000>;
++		clock-frequency = <24390000>;
 +		clock-output-names = "serializer_clk";
-+		pwms = <&pwm2 0 42>; /* 42ns - 24 MHz */
++		pwms = <&pwm2 0 41>; /* 41ns - 24.39 MHz */
  	};
  };
  


### PR DESCRIPTION
This seems to fix really bad frames.

The question "why?" is still unanswered...