### PR TITLE
Fix/migl/rdphoen 1299 ro nfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,7 +114,8 @@ and this project adheres to [APR's Version Numbering](https://apr.apache.org/ver
 ### Fixed
 - [RDPHOEN-1013]: Fix setting the format on the Serializer, enables switching between Raw12 and Raw14 formats without setting the format twice
 - [RDPHOEN-1150]: Fix fsl-dsp devicetree node in linux-fslc, place reserved memory region inside RAM bounds
-
+- [RDPHOEN-1299]: Fix r/w access on netfitboot
+- [RDPHOEN-1299]: Fix init script terminal output
 
 
 ## [2.0.3] - 2022-03-23

--- a/recipes-core/initrdscripts/files/initramfs-init-netboot.sh
+++ b/recipes-core/initrdscripts/files/initramfs-init-netboot.sh
@@ -54,6 +54,9 @@ echo "####################################################"
 echo; echo; echo
 
 ${MOUNT} -t nfs "${NFSPATH}" ${ROOT_MNT}
+${MOUNT} --move /dev ${ROOT_MNT}/dev
+${MOUNT} --move /proc ${ROOT_MNT}/proc
+${MOUNT} --move /sys ${ROOT_MNT}/sys
 
 #Switch to real root
 echo "Switch to root"

--- a/recipes-core/initrdscripts/files/initramfs-init.sh
+++ b/recipes-core/initrdscripts/files/initramfs-init.sh
@@ -212,6 +212,9 @@ debug "Opening verity device: ${DECRYPT_ROOT_DEV}"
 veritysetup open ${DECRYPT_ROOT_DEV} ${VERITY_NAME} ${ROOT_HASH_DEV} ${RH}
 
 ${MOUNT} ${VERITY_DEV} ${ROOT_MNT} -o ro
+${MOUNT} --move /dev ${ROOT_MNT}/dev
+${MOUNT} --move /proc ${ROOT_MNT}/proc
+${MOUNT} --move /sys ${ROOT_MNT}/sys
 
 #Switch to real root
 echo "Switch to root"

--- a/recipes-core/initscripts/initscripts_%.bbappend
+++ b/recipes-core/initscripts/initscripts_%.bbappend
@@ -1,0 +1,6 @@
+do_install_append() {
+	# Remove S06checkroot.sh symlink to avoid "ro" /
+	# remounting when using nfs boot and expecting rw access
+	# from prior mounting in the initramfs init script.
+	update-rc.d -f -r ${D} checkroot.sh remove
+}


### PR DESCRIPTION
**What's new?**
- [RDPHOEN-1299]: Fix r/w access on netfitboot
- [RDPHOEN-1299]: Fix init script terminal output

**CI:** https://gitlab.devops.defra01.iris-sensing.net/MIRROR/iris-kas/-/pipelines/1934

**Build**
- Copy fw files from gitlab
- netboot fitImage needs to be build maually for now:
`bitbake mc:imx8mp-irma6r2:irma6-fitimage-netboot`

**Test**
1. NFS-Boot: nfs share has r/w access on first boot (maintenance) and count_von_count is running (please check ps output)
2. There is no /srv/nfs/dev/null or /srv/nfs/dev/tty0 after 2. boot on NFS-Host
3. Flash-Boot (maintenance): Check if init scripts produce output like the following: `INIT: version 2.96 booting` and count_von_count is running
4. Flash-Boot (deploy): Same as 3.
5. Test if R1 still works!