### PR TITLE
[APC-7088] Set VB2_MAX_FRAME/VIDEO_MAX_FRAME up to 128 (from former 32)

### DIFF
--- a/recipes-kernel/linux/linux-fslc-iris.inc
+++ b/recipes-kernel/linux/linux-fslc-iris.inc
@@ -46,6 +46,7 @@ SRC_URI += " \
     file://0040-tc358746-Use-gpio-reset-instead-of-sotware-reset.patch \
     file://0041-EPC660-Update-sequencer-code-to-V14-Datasheet-V2.20.patch \
     file://0042-epc660-remove-the-register-setting-of-EPC660_REG_LED.patch \
+    file://0043-Set-VB2_MAX_FRAME-VIDEO_MAX_FRAME-up-to-128.patch \
 "
 
 SRC_URI:append:poky-iris-deploy = "\

--- a/recipes-kernel/linux/linux-fslc-iris/0043-Set-VB2_MAX_FRAME-VIDEO_MAX_FRAME-up-to-128.patch
+++ b/recipes-kernel/linux/linux-fslc-iris/0043-Set-VB2_MAX_FRAME-VIDEO_MAX_FRAME-up-to-128.patch
@@ -1,0 +1,40 @@
+From 6d72535c29c3975cce30c0fd7fffb0072023d771 Mon Sep 17 00:00:00 2001
+From: Jan Hannig <jan.hannig@iris-sensing.com>
+Date: Fri, 29 Sep 2023 15:03:30 +0200
+Subject: [PATCH] Set VB2_MAX_FRAME/VIDEO_MAX_FRAME up to 128 (from former 32)
+
+Signed-off-by: Jan Hannig <jan.hannig@iris-sensing.com>
+---
+ include/media/videobuf2-core.h | 2 +-
+ include/uapi/linux/videodev2.h | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/include/media/videobuf2-core.h b/include/media/videobuf2-core.h
+index 3b5986cee073..401bb9231d32 100644
+--- a/include/media/videobuf2-core.h
++++ b/include/media/videobuf2-core.h
+@@ -20,7 +20,7 @@
+ #include <media/media-request.h>
+ #include <media/frame_vector.h>
+ 
+-#define VB2_MAX_FRAME	(32)
++#define VB2_MAX_FRAME (128)
+ #define VB2_MAX_PLANES	(8)
+ 
+ /**
+diff --git a/include/uapi/linux/videodev2.h b/include/uapi/linux/videodev2.h
+index 03bf55ed2622..1495821a058e 100644
+--- a/include/uapi/linux/videodev2.h
++++ b/include/uapi/linux/videodev2.h
+@@ -70,7 +70,7 @@
+  * Common stuff for both V4L1 and V4L2
+  * Moved from videodev.h
+  */
+-#define VIDEO_MAX_FRAME               32
++#define VIDEO_MAX_FRAME              128
+ #define VIDEO_MAX_PLANES               8
+ 
+ /*
+-- 
+2.30.2
+

--- a/recipes-kernel/linux/linux-gen6.bb
+++ b/recipes-kernel/linux/linux-gen6.bb
@@ -35,7 +35,7 @@ require recipes-kernel/linux/linux-yocto.inc
 
 BRANCH = "develop"
 LINUX_VERSION ?= "4.14.239"
-SRCREV="3e65924bb4b1d931fde65e61a2e38b027d51245b"
+SRCREV="a8eff8781434a794b3916d0ee13043a0a16ee215"
 
 SRC_URI = "git://github.com/iris-GmbH/linux-gen6.git;protocol=https;bareclone=1;branch=${BRANCH};depth=1"
 


### PR DESCRIPTION
Local Yocto run for both Releases successfully built and tested.

For testing the pipeline build result, use the branch 
feature/jaha/APC-7187 in HAL::Imager 

In the terminal output, it should be visible that the platform application is able to require 124/128 buffers instead of 32 with the platform application on develop.